### PR TITLE
Improve StartsWithAddedToken to return the longest matching token.

### DIFF
--- a/src/FastBertTokenizer/BertTokenizer.LoadTokenizerJson.cs
+++ b/src/FastBertTokenizer/BertTokenizer.LoadTokenizerJson.cs
@@ -160,7 +160,7 @@ public partial class BertTokenizer
             prefixes[new(addedToken.Content)] = addedToken.Id;
         }
 
-        _addedTokens = new(tok.AddedTokens.Select(x => (x.Content, x.Normalized)));
+        _addedTokens = new(tok.AddedTokens.Select(x => (x.Content, x.Normalized)).OrderByDescending(x => x.Content.Length));
 
 #if NET8_0_OR_GREATER
         _prefixes = prefixes.ToFrozenDictionary();

--- a/src/FastBertTokenizer/PreTokenizingEnumerator.cs
+++ b/src/FastBertTokenizer/PreTokenizingEnumerator.cs
@@ -158,20 +158,15 @@ internal ref struct PreTokenizingEnumerator
 
     private readonly (int Length, bool Normalize)? StartsWithAddedToken(ReadOnlySpan<char> value)
     {
-        (int Length, bool Normalize)? maxMatch = null;
-
         foreach (var (content, normalize) in _addedTokens.Tokens)
         {
             if (value.StartsWith(content.AsSpan(), normalize ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
             {
-                if (maxMatch == null || content.Length > maxMatch.Value.Length)
-                {
-                    maxMatch = (content.Length, normalize);
-                }
+                return (content.Length, normalize);
             }
         }
 
-        return maxMatch;
+        return null;
     }
 
     // AggressiveInlining the methods below does seem to provide a performance boost in the 2-6% ballpark of the overall tokenizer.

--- a/src/FastBertTokenizer/PreTokenizingEnumerator.cs
+++ b/src/FastBertTokenizer/PreTokenizingEnumerator.cs
@@ -158,15 +158,20 @@ internal ref struct PreTokenizingEnumerator
 
     private readonly (int Length, bool Normalize)? StartsWithAddedToken(ReadOnlySpan<char> value)
     {
+        (int Length, bool Normalize)? maxMatch = null;
+
         foreach (var (content, normalize) in _addedTokens.Tokens)
         {
             if (value.StartsWith(content.AsSpan()))
             {
-                return (content.Length, normalize);
+                if (maxMatch == null || content.Length > maxMatch.Value.Length)
+                {
+                    maxMatch = (content.Length, normalize);
+                }
             }
         }
 
-        return null;
+        return maxMatch;
     }
 
     // AggressiveInlining the methods below does seem to provide a performance boost in the 2-6% ballpark of the overall tokenizer.


### PR DESCRIPTION
This PR enhances the StartsWithAddedToken method to return the longest matching token instead of the first match.

Changes:
Updated the loop logic to track the longest match instead of returning immediately.

Benefits:
Ensures the function finds the most specific match, rather than stopping at the first one.
