### PR TITLE
Performance research: faster pre-tokenization via char-class table, bound WordPiece matching length

### DIFF
--- a/src/FastBertTokenizer/AddedTokens.cs
+++ b/src/FastBertTokenizer/AddedTokens.cs
@@ -17,7 +17,7 @@ internal class AddedTokens
 
         // This logic might not be perfect. Are there chars that are equal to others in an invariant case insesitive comparison
         // but are neither the upper nor the lower variant of the original?
-        var firstLettersToSearch = addedTokens
+        var firstLettersToSearch = Tokens
             .SelectMany(x => x.Normalize
                 ? (IEnumerable<char>)[x.Content[0], char.ToLowerInvariant(x.Content[0]), char.ToUpperInvariant(x.Content[0])]
                 : [x.Content[0]])

--- a/src/FastBertTokenizer/AddedTokens.cs
+++ b/src/FastBertTokenizer/AddedTokens.cs
@@ -7,6 +7,10 @@ namespace FastBertTokenizer;
 
 internal class AddedTokens
 {
+    public const byte CharClassWhitespace = 1;
+    public const byte CharClassPunctuationOrChinese = 2;
+    public const byte CharClassAddedTokenFirstLetter = 4;
+
     public AddedTokens(IEnumerable<(string Content, bool Normalize)> addedTokens)
     {
         Tokens = [.. addedTokens];
@@ -23,9 +27,50 @@ internal class AddedTokens
 #else
         FirstLetters = [.. firstLettersToSearch];
 #endif
+
+        // Classify every BMP char once so that the pre-tokenizer's per-char hot loop
+        // is a single table lookup instead of multiple class checks per char.
+        var charClasses = new byte[char.MaxValue + 1];
+        for (var i = 0; i <= char.MaxValue; i++)
+        {
+            var c = (char)i;
+            byte cls = 0;
+            if (char.IsWhiteSpace(c))
+            {
+                cls |= CharClassWhitespace;
+            }
+
+            if (PreTokenizingEnumerator.IsPunctuation(c) || PreTokenizingEnumerator.IsChineseCharacter(c))
+            {
+                cls |= CharClassPunctuationOrChinese;
+            }
+
+            charClasses[i] = cls;
+        }
+
+        foreach (var (content, normalize) in Tokens)
+        {
+            var c = content[0];
+            charClasses[c] |= CharClassAddedTokenFirstLetter;
+            if (normalize)
+            {
+                charClasses[char.ToLowerInvariant(c)] |= CharClassAddedTokenFirstLetter;
+                charClasses[char.ToUpperInvariant(c)] |= CharClassAddedTokenFirstLetter;
+            }
+        }
+
+        CharClasses = charClasses;
     }
 
     public (string Content, bool Normalize)[] Tokens { get; }
+
+    /// <summary>
+    /// Gets a per-char classification table for all BMP chars, built from the
+    /// <see cref="CharClassWhitespace"/>, <see cref="CharClassPunctuationOrChinese"/> and
+    /// <see cref="CharClassAddedTokenFirstLetter"/> flags. A value of 0 means the char is an
+    /// ordinary word char.
+    /// </summary>
+    public byte[] CharClasses { get; }
 
 #if NET8_0_OR_GREATER
     public SearchValues<char> FirstLetters { get; }

--- a/src/FastBertTokenizer/BertTokenizer.LoadTokenizerJson.cs
+++ b/src/FastBertTokenizer/BertTokenizer.LoadTokenizerJson.cs
@@ -167,6 +167,7 @@ public partial class BertTokenizer
 
         _addedTokens = new(tok.AddedTokens.Select(x => (x.Content, x.Normalized)).OrderByDescending(x => x.Content.Length));
 
+        SetMaxTokenCharLens(prefixes, suffixes);
 #if NET8_0_OR_GREATER
         _prefixes = prefixes.ToFrozenDictionary();
         _suffixes = suffixes.ToFrozenDictionary();

--- a/src/FastBertTokenizer/BertTokenizer.LoadVocab.cs
+++ b/src/FastBertTokenizer/BertTokenizer.LoadVocab.cs
@@ -148,6 +148,7 @@ public partial class BertTokenizer
             _sep = (sepId ?? throw new InvalidOperationException($"Vocabulary does not contain sep token {sepToken}."), sepToken);
             _pad = (padId ?? throw new InvalidOperationException($"Vocabulary does not contain pad token {padToken}."), padToken);
 
+            SetMaxTokenCharLens(prefixes, suffixes);
 #if NET8_0_OR_GREATER
             _prefixes = prefixes.ToFrozenDictionary();
             _suffixes = suffixes.ToFrozenDictionary();

--- a/src/FastBertTokenizer/BertTokenizer.cs
+++ b/src/FastBertTokenizer/BertTokenizer.cs
@@ -33,6 +33,8 @@ public partial class BertTokenizer
     private Dictionary<StringSpanOrdinalKey, long>? _prefixes;
     private Dictionary<StringSpanOrdinalKey, long>? _suffixes;
 #endif
+    private int _maxPrefixCharLen = int.MaxValue;
+    private int _maxSuffixCharLen = int.MaxValue;
     private (int Id, string Token) _unk = default!;
     private (int Id, string Token) _cls = default!;
     private (int Id, string Token) _sep = default!;
@@ -550,7 +552,10 @@ public partial class BertTokenizer
         }
 
         // No null checks for _prefixes and _suffixes because this is a private method.
-        var prefix = word;
+        // Prefixes/suffixes longer than the longest vocabulary entry can never match, so don't
+        // even try to look them up. For pathologically long words this avoids hashing the same
+        // long spans over and over again while shrinking the candidate prefix char by char.
+        var prefix = word.Length > _maxPrefixCharLen ? word.Slice(0, _maxPrefixCharLen) : word;
         var cnt = 0;
         long id = -1;
 
@@ -577,7 +582,7 @@ public partial class BertTokenizer
         offset += prefix.Length;
         while (remaining.Length > 0 && cnt < tokenIdSink.Length)
         {
-            var suffix = remaining;
+            var suffix = remaining.Length > _maxSuffixCharLen ? remaining.Slice(0, _maxSuffixCharLen) : remaining;
             id = -1;
 
             while (suffix.Length > 0)
@@ -603,6 +608,39 @@ public partial class BertTokenizer
         }
 
         return cnt;
+    }
+
+#if NET9_0_OR_GREATER
+    private void SetMaxTokenCharLens(Dictionary<string, long> prefixes, Dictionary<string, long> suffixes)
+    {
+        static int MaxKeyLen(Dictionary<string, long> dict)
+        {
+            var max = 0;
+            foreach (var key in dict.Keys)
+            {
+                max = Math.Max(max, key.Length);
+            }
+
+            return max;
+        }
+#else
+    private void SetMaxTokenCharLens(Dictionary<StringSpanOrdinalKey, long> prefixes, Dictionary<StringSpanOrdinalKey, long> suffixes)
+    {
+        static int MaxKeyLen(Dictionary<StringSpanOrdinalKey, long> dict)
+        {
+            var max = 0;
+            foreach (var key in dict.Keys)
+            {
+                // Keys stored in the dictionary are always string-backed.
+                max = Math.Max(max, key.Data!.Length);
+            }
+
+            return max;
+        }
+#endif
+
+        _maxPrefixCharLen = MaxKeyLen(prefixes);
+        _maxSuffixCharLen = MaxKeyLen(suffixes);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/FastBertTokenizer/PreTokenizingEnumerator.cs
+++ b/src/FastBertTokenizer/PreTokenizingEnumerator.cs
@@ -53,11 +53,23 @@ internal ref struct PreTokenizingEnumerator
 
     public bool MoveNext()
     {
+        var charClasses = _addedTokens.CharClasses;
         while (currentIndex < _input.Length)
         {
             var c = _input[currentIndex];
+            var cls = charClasses[c];
 
-            if (_addedTokens.FirstLetters.Contains(c) && StartsWithAddedToken(_input.Slice(currentIndex)) is (int len, bool normalize))
+            if (cls == 0)
+            {
+                // Ordinary word char; by far the most common case.
+                if (start == -1)
+                {
+                    start = currentIndex;
+                }
+
+                currentIndex++;
+            }
+            else if ((cls & AddedTokens.CharClassAddedTokenFirstLetter) != 0 && StartsWithAddedToken(_input.Slice(currentIndex)) is (int len, bool normalize))
             {
                 if (Flush())
                 {
@@ -68,7 +80,7 @@ internal ref struct PreTokenizingEnumerator
                 currentIndex += len;
                 return true;
             }
-            else if (char.IsWhiteSpace(c))
+            else if ((cls & AddedTokens.CharClassWhitespace) != 0)
             {
                 if (Flush())
                 {
@@ -78,7 +90,7 @@ internal ref struct PreTokenizingEnumerator
 
                 currentIndex++;
             }
-            else if (IsPunctuation(c) || IsChineseCharacter(c))
+            else if ((cls & AddedTokens.CharClassPunctuationOrChinese) != 0)
             {
                 if (Flush())
                 {
@@ -91,6 +103,8 @@ internal ref struct PreTokenizingEnumerator
             }
             else
             {
+                // A char that is only flagged as a possible added token first letter but
+                // didn't actually start an added token; treat it as an ordinary word char.
                 if (start == -1)
                 {
                     start = currentIndex;
@@ -178,7 +192,8 @@ internal ref struct PreTokenizingEnumerator
     /// <returns>True we consider the character a punctuation character, otherwise false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Makes more sense here.")]
-    private static bool IsPunctuation(char cp)
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1202:Elements should be ordered by access", Justification = "Makes more sense here.")]
+    internal static bool IsPunctuation(char cp)
     {
         // We treat all non-letter/number ASCII as punctuation.
         // Characters such as "^", "$", and "`" are not in the Unicode
@@ -207,7 +222,7 @@ internal ref struct PreTokenizingEnumerator
     /// <param name="cp">Char to check.</param>
     /// <returns>True if passed char is a chinese char.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsChineseCharacter(char cp)
+    internal static bool IsChineseCharacter(char cp)
     {
         // This defines a "chinese character" as anything in the CJK Unicode block:
         //   https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_(Unicode_block)


### PR DESCRIPTION
# Performance improvement research: validated findings

This PR is the outcome of a performance research pass over the tokenizer hot path. Every candidate was prototyped and measured; the two changes included here are the ones that survived validation. Rejected candidates and remaining opportunities are documented below so the work is reproducible.

## Methodology

- Corpus: `data/wiki-simple.json.br` (15 000 articles, 26.3 M chars), vocab `data/baai-bge-small-en/vocab.txt`, lowercased, .NET 10, x64 Linux (cloud VM).
- Phase attribution via a scratch harness that compiles the library sources directly, so internal phases (`PreTokenizingEnumerator` alone vs. full `Encode`) could be timed separately.
- A/B comparisons ran interleaved (base, opt, base, opt, …) because the VM showed ±5 % drift; a candidate only counts as validated if it won in every interleaved round.
- Correctness: full test suite (68 tests, incl. the HuggingFace-tokenizer comparison over the corpus) on net8.0 and net10.0, plus identical token-output checksums in the harness for every variant.

## Phase breakdown (baseline, full-document encode, 15 000 docs)

| Phase | Time | Share |
|---|---|---|
| Pre-tokenization (char scanning) | ~170 ms | ~45 % |
| Lowercasing | ~30 ms | ~8 % |
| WordPiece (dict lookups + writes) | ~180 ms | ~47 % |
| **Total** | **~378 ms** | 100 % |

The per-char scanning loop was the single largest cost: each input char went through up to four class checks (`FirstLetters.Contains`, `char.IsWhiteSpace`, `IsPunctuation`, `IsChineseCharacter`).

## Validated change 1: per-char classification table in the pre-tokenizer

`AddedTokens` now precomputes a 64 KiB `byte[65536]` table at vocabulary load that classifies every BMP char (whitespace / punctuation-or-CJK / added-token first letter / ordinary word char). `PreTokenizingEnumerator.MoveNext` replaces the four per-char checks with a single table lookup; the check cascade and therefore the emitted segments are exactly unchanged.

Interleaved A/B results (min of 5 in-process iterations, 3+ rounds each):

| Scenario | Before | After | Δ |
|---|---|---|---|
| Pre-tokenization only (no lowercase), isolated | ~128 ms | ~91 ms | −29 % |
| Full-document `Encode` | ~385–405 ms | ~337–356 ms | ~−12 % |
| 512-token truncated `Encode` (benchmark scenario) | ~239–245 ms | ~207–230 ms | ~−8–13 % |

One-time cost: ~65 KiB allocation + one `GetUnicodeCategory` pass over the BMP per `LoadVocabulary`/`LoadTokenizerJson` call.

## Validated change 2: cap WordPiece candidate length at the longest vocab entry

The greedy longest-prefix/suffix match started with the whole remaining word. Every failed probe hashes the candidate span, so a single pathological "word" of length L cost O(L²) char-hashing work (one 5 000-char token ≈ 12.5 M hashed chars). Prefixes longer than the longest vocabulary entry (18 chars prefix / 10 chars suffix for baai-bge-small-en) can never match, so the loaders now record the max entry lengths and `TokenizeSubword` starts matching at that cap. Output is provably unchanged.

| Scenario | Before | After | Δ |
|---|---|---|---|
| 20 docs × 20 "words" of 5 000 chars each | ~4 900 ms | ~59 ms | ~83× faster |
| Wiki corpus encode | within noise | within noise | — |

This also bounds the work an adversarial input can cause for services tokenizing untrusted input (HuggingFace guards the same case with `max_input_chars_per_word=100`; FastBertTokenizer previously had no equivalent bound).

## BenchmarkDotNet confirmation

`TokenizeSpeed.SinglethreadedAllocating` on an otherwise idle machine, local build (this branch, both changes) vs. released 1.0.28 NuGet baseline. Note the baseline delta also includes master's existing improvements over 1.0.28 (e.g. #134); the isolated effect of this PR is the interleaved A/B numbers above.

| Job | Mean | StdDev |
|---|---|---|
| local (this branch), .NET 10 | 231.9 ms | 4.94 ms |
| local (this branch), .NET 8 | 300.0 ms | 15.38 ms |
| nuget 1.0.28, .NET 10 | 316.3 ms | 11.23 ms |
| nuget 1.0.28, .NET 8 | 340.3 ms | 13.06 ms |

## Prototyped and rejected (with data)

- **Vectorized word-run skipping via `SearchValues<char>`/`IndexOfAny`** over all non-word chars: −29 % on the isolated non-lowercased scanning phase, but no end-to-end win (and occasional small regressions) in the default lowercased scenario across interleaved rounds. The fixed per-call overhead of `IndexOfAny` roughly cancels the scalar savings at typical English word lengths once the rest of the pipeline is in play. Not worth the complexity on this evidence; might be worth revisiting for cased models or other hardware.
- **Skip `ToLowerInvariant` for already-lowercase ASCII segments**: no measurable end-to-end effect (lowercasing is only ~8 % of total and .NET's vectorized ASCII casing is already fast); the extra scan pass sometimes showed as a small regression. Reverted.

## Remaining opportunities (identified, not implemented)

- **WordPiece phase (~47 % of full-doc encode, ~31 ns/token)**: a trie / double-array automaton could replace the shrink-and-rehash loop, but the common case (whole word found on first probe) is already a single `FrozenDictionary` probe on net8+, so expected gains are uncertain — needs a careful prototype.
- **Word-level token-id cache** (HuggingFace-style LRU over frequent words): only helps multi-token words; Zipf distribution suggests modest gains; adds memory/complexity.
- **netstandard2.0 path**: still uses `Dictionary` + `StringSpanOrdinalKey` (no `FrozenDictionary`). The char-class table from this PR helps there too (it is TFM-independent), but the dictionary gap remains for .NET Framework consumers.
- The benchmark VM had ±5 % noise; small-effect candidates (1–3 %) are not measurable in this environment and were not pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USHtEGd3aCFih58M7KVMSd