### PR TITLE
Prototype: Python binding via NativeAOT C ABI

### DIFF
--- a/src/FastBertTokenizer.Native/FastBertTokenizer.Native.csproj
+++ b/src/FastBertTokenizer.Native/FastBertTokenizer.Native.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishAot>true</PublishAot>
+    <NativeLib>Shared</NativeLib>
+    <!-- Publishes FastBertTokenizer.Native.so / .dylib / .dll depending on the target platform. -->
+    <RootNamespace>FastBertTokenizer.Native</RootNamespace>
+    <OptimizationPreference>Speed</OptimizationPreference>
+    <IsPackable>false</IsPackable>
+    <!-- The C ABI's parameter semantics are documented in the conventions block and per-function
+         summaries in NativeExports.cs; per-parameter XML docs would just duplicate that. -->
+    <NoWarn>$(NoWarn);SA1611;SA1615</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../FastBertTokenizer/FastBertTokenizer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/FastBertTokenizer.Native/NativeExports.cs
+++ b/src/FastBertTokenizer.Native/NativeExports.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -29,6 +30,13 @@ internal static unsafe class NativeExports
     private const int ErrInvalidArgument = -3;
     private const int ErrBufferTooSmall = -4;
 
+    // Handles are opaque ids into this table rather than raw GCHandles: resolving an arbitrary
+    // caller-supplied value through GCHandle.FromIntPtr is undefined behavior (a garbage value
+    // can hard-abort the process with an access violation), while a dictionary lookup makes
+    // invalid, stale and double-destroyed handles reliably fail with ErrInvalidHandle.
+    private static readonly ConcurrentDictionary<nint, BertTokenizer> Instances = new();
+    private static long _nextHandle;
+
     [ThreadStatic]
     private static string? _lastError;
 
@@ -44,7 +52,9 @@ internal static unsafe class NativeExports
     {
         try
         {
-            return GCHandle.ToIntPtr(GCHandle.Alloc(new BertTokenizer()));
+            var handle = (nint)Interlocked.Increment(ref _nextHandle);
+            Instances[handle] = new BertTokenizer();
+            return handle;
         }
         catch (Exception ex)
         {
@@ -53,13 +63,17 @@ internal static unsafe class NativeExports
         }
     }
 
-    /// <summary>Destroy a tokenizer instance created by <c>fbt_create</c>. Passing 0 is a no-op.</summary>
+    /// <summary>
+    /// Destroy a tokenizer instance created by <c>fbt_create</c>. Passing 0 is a no-op.
+    /// Best-effort: an invalid or already-destroyed handle is reported via <c>fbt_last_error</c>
+    /// instead of failing.
+    /// </summary>
     [UnmanagedCallersOnly(EntryPoint = "fbt_destroy")]
     public static void Destroy(nint handle)
     {
-        if (handle != 0)
+        if (handle != 0 && !Instances.TryRemove(handle, out _))
         {
-            GCHandle.FromIntPtr(handle).Free();
+            _lastError = "handle does not refer to a live tokenizer instance.";
         }
     }
 
@@ -316,18 +330,14 @@ internal static unsafe class NativeExports
 
     private static BertTokenizer? Resolve(nint handle)
     {
-        if (handle == 0)
-        {
-            _lastError = "handle must not be 0.";
-            return null;
-        }
-
-        if (GCHandle.FromIntPtr(handle).Target is BertTokenizer tok)
+        if (Instances.TryGetValue(handle, out var tok))
         {
             return tok;
         }
 
-        _lastError = "handle does not refer to a tokenizer instance.";
+        _lastError = handle == 0
+            ? "handle must not be 0."
+            : "handle does not refer to a live tokenizer instance.";
         return null;
     }
 

--- a/src/FastBertTokenizer.Native/NativeExports.cs
+++ b/src/FastBertTokenizer.Native/NativeExports.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -47,7 +48,7 @@ internal static unsafe class NativeExports
     private static nint _lastErrorUtf8;
 
     /// <summary>Create a new tokenizer instance. Returns an opaque handle, or 0 on failure.</summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_create")]
+    [UnmanagedCallersOnly(EntryPoint = "fbt_create", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static nint Create()
     {
         try
@@ -68,7 +69,7 @@ internal static unsafe class NativeExports
     /// Best-effort: an invalid or already-destroyed handle is reported via <c>fbt_last_error</c>
     /// instead of failing.
     /// </summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_destroy")]
+    [UnmanagedCallersOnly(EntryPoint = "fbt_destroy", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static void Destroy(nint handle)
     {
         if (handle != 0 && !Instances.TryRemove(handle, out _))
@@ -81,7 +82,7 @@ internal static unsafe class NativeExports
     /// Load a Hugging Face tokenizer.json (UTF-8 bytes). The caller keeps ownership of the buffer;
     /// it is not referenced after this call returns.
     /// </summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_load_tokenizer_json")]
+    [UnmanagedCallersOnly(EntryPoint = "fbt_load_tokenizer_json", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static int LoadTokenizerJson(nint handle, byte* json, nint jsonByteLen)
     {
         try
@@ -112,7 +113,7 @@ internal static unsafe class NativeExports
     /// Load a vocab.txt (UTF-8 bytes). <paramref name="convertInputToLowercase"/> != 0 enables lowercasing,
     /// as for uncased models. The caller keeps ownership of the buffer.
     /// </summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_load_vocab_txt")]
+    [UnmanagedCallersOnly(EntryPoint = "fbt_load_vocab_txt", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static int LoadVocabTxt(nint handle, byte* vocab, nint vocabByteLen, int convertInputToLowercase)
     {
         try
@@ -146,7 +147,7 @@ internal static unsafe class NativeExports
     /// per input). <paramref name="tokenTypeIds"/> may be null; if given it is zero-filled.
     /// <paramref name="parallel"/> != 0 tokenizes on the .NET thread pool (recommended for large batches).
     /// </summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_encode_batch")]
+    [UnmanagedCallersOnly(EntryPoint = "fbt_encode_batch", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static int EncodeBatch(
         nint handle,
         byte** texts,
@@ -177,6 +178,15 @@ internal static unsafe class NativeExports
             {
                 _lastError = $"count * maxTokens must be <= {int.MaxValue} per call; split the batch.";
                 return ErrInvalidArgument;
+            }
+
+            for (var i = 0; i < count; i++)
+            {
+                if (textByteLens[i] < 0 || (texts[i] is null && textByteLens[i] > 0))
+                {
+                    _lastError = $"texts[{i}] is null with a positive length or textByteLens[{i}] is negative.";
+                    return ErrInvalidArgument;
+                }
             }
 
             var inputs = MaterializeStrings(texts, textByteLens, count, parallel != 0);
@@ -219,7 +229,7 @@ internal static unsafe class NativeExports
     /// <paramref name="inputIds"/> and <paramref name="attentionMask"/> (padded to <paramref name="maxTokens"/>).
     /// Returns the number of non-padding tokens produced, or a negative error code.
     /// </summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_encode")]
+    [UnmanagedCallersOnly(EntryPoint = "fbt_encode", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static int EncodeSingle(nint handle, byte* text, int textByteLen, int maxTokens, long* inputIds, long* attentionMask)
     {
         try
@@ -256,7 +266,7 @@ internal static unsafe class NativeExports
     /// and returns 0; otherwise returns <c>ErrBufferTooSmall</c> (-4) without writing text.
     /// Call with <paramref name="outUtf8"/> = null to query the required size.
     /// </summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_decode")]
+    [UnmanagedCallersOnly(EntryPoint = "fbt_decode", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static int Decode(nint handle, long* tokenIds, int count, byte* outUtf8, long outByteLen, long* outRequiredByteLen)
     {
         try
@@ -294,36 +304,45 @@ internal static unsafe class NativeExports
     /// Returns a NUL-terminated UTF-8 message describing the last error on the calling thread,
     /// or 0 if none occurred. The pointer stays valid until the next failing call on the same thread.
     /// </summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_last_error")]
+    [UnmanagedCallersOnly(EntryPoint = "fbt_last_error", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static nint LastError()
     {
-        var msg = _lastError;
-        if (msg is null)
+        try
         {
-            return 0;
-        }
+            var msg = _lastError;
+            if (msg is null)
+            {
+                return 0;
+            }
 
-        // Repeated queries must return the same buffer while no new failure occurred - the
-        // documented lifetime is "valid until the next failing call on this thread". Only
-        // re-encode (and free the previous buffer) once the message actually changed.
-        if (_lastErrorUtf8 != 0 && ReferenceEquals(_lastErrorMaterialized, msg))
-        {
+            // Repeated queries must return the same buffer while no new failure occurred - the
+            // documented lifetime is "valid until the next failing call on this thread". Only
+            // re-encode (and free the previous buffer) once the message actually changed.
+            if (_lastErrorUtf8 != 0 && ReferenceEquals(_lastErrorMaterialized, msg))
+            {
+                return _lastErrorUtf8;
+            }
+
+            if (_lastErrorUtf8 != 0)
+            {
+                NativeMemory.Free((void*)_lastErrorUtf8);
+                _lastErrorUtf8 = 0;
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(msg);
+            var buf = (byte*)NativeMemory.Alloc((nuint)bytes.Length + 1);
+            bytes.CopyTo(new Span<byte>(buf, bytes.Length));
+            buf[bytes.Length] = 0;
+            _lastErrorUtf8 = (nint)buf;
+            _lastErrorMaterialized = msg;
             return _lastErrorUtf8;
         }
-
-        if (_lastErrorUtf8 != 0)
+        catch (Exception)
         {
-            NativeMemory.Free((void*)_lastErrorUtf8);
-            _lastErrorUtf8 = 0;
+            // Even allocation failure must not escape an [UnmanagedCallersOnly] export;
+            // "no message available" is the only safe answer here.
+            return 0;
         }
-
-        var bytes = Encoding.UTF8.GetBytes(msg);
-        var buf = (byte*)NativeMemory.Alloc((nuint)bytes.Length + 1);
-        bytes.CopyTo(new Span<byte>(buf, bytes.Length));
-        buf[bytes.Length] = 0;
-        _lastErrorUtf8 = (nint)buf;
-        _lastErrorMaterialized = msg;
-        return _lastErrorUtf8;
     }
 
     private static void SetLastError(Exception ex) => _lastError = ex.ToString();

--- a/src/FastBertTokenizer.Native/NativeExports.cs
+++ b/src/FastBertTokenizer.Native/NativeExports.cs
@@ -278,9 +278,9 @@ internal static unsafe class NativeExports
                 return ErrInvalidHandle;
             }
 
-            if (tokenIds is null || count < 0 || outRequiredByteLen is null)
+            if (tokenIds is null || count < 0 || outRequiredByteLen is null || outByteLen < 0)
             {
-                _lastError = "tokenIds and outRequiredByteLen must not be null and count must be >= 0.";
+                _lastError = "tokenIds and outRequiredByteLen must not be null; count and outByteLen must be >= 0.";
                 return ErrInvalidArgument;
             }
 

--- a/src/FastBertTokenizer.Native/NativeExports.cs
+++ b/src/FastBertTokenizer.Native/NativeExports.cs
@@ -1,0 +1,378 @@
+// Copyright (c) Georg Jung. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace FastBertTokenizer.Native;
+
+/// <summary>
+/// Flat C ABI over <see cref="BertTokenizer"/> for consumption from non-.NET languages
+/// (Python via ctypes/cffi, Node via ffi, etc.) when published as a NativeAOT shared library.
+///
+/// Conventions:
+/// <list type="bullet">
+/// <item>All text crosses the boundary as UTF-8 (pointer + byte length, no NUL termination required).</item>
+/// <item>Functions returning <c>int</c> return 0 on success and a negative error code on failure;
+/// <c>fbt_last_error</c> returns a UTF-8 error message for the last failure on the calling thread.</item>
+/// <item>Output buffers are allocated by the caller. For encode, <c>input_ids</c>/<c>attention_mask</c>
+/// must hold <c>count * max_tokens</c> int64 values; results are written row-major, padded per row —
+/// i.e. exactly the memory layout of a C-contiguous numpy array of shape (count, max_tokens).</item>
+/// </list>
+/// </summary>
+internal static unsafe class NativeExports
+{
+    private const int Ok = 0;
+    private const int ErrException = -1;
+    private const int ErrInvalidHandle = -2;
+    private const int ErrInvalidArgument = -3;
+    private const int ErrBufferTooSmall = -4;
+
+    [ThreadStatic]
+    private static string? _lastError;
+
+    [ThreadStatic]
+    private static nint _lastErrorUtf8;
+
+    /// <summary>Create a new tokenizer instance. Returns an opaque handle, or 0 on failure.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "fbt_create")]
+    public static nint Create()
+    {
+        try
+        {
+            return GCHandle.ToIntPtr(GCHandle.Alloc(new BertTokenizer()));
+        }
+        catch (Exception ex)
+        {
+            SetLastError(ex);
+            return 0;
+        }
+    }
+
+    /// <summary>Destroy a tokenizer instance created by <c>fbt_create</c>. Passing 0 is a no-op.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "fbt_destroy")]
+    public static void Destroy(nint handle)
+    {
+        if (handle != 0)
+        {
+            GCHandle.FromIntPtr(handle).Free();
+        }
+    }
+
+    /// <summary>
+    /// Load a Hugging Face tokenizer.json (UTF-8 bytes). The caller keeps ownership of the buffer;
+    /// it is not referenced after this call returns.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "fbt_load_tokenizer_json")]
+    public static int LoadTokenizerJson(nint handle, byte* json, nint jsonByteLen)
+    {
+        try
+        {
+            if (Resolve(handle) is not { } tok)
+            {
+                return ErrInvalidHandle;
+            }
+
+            if (json is null || jsonByteLen < 0)
+            {
+                _lastError = "json must not be null and jsonByteLen must be >= 0.";
+                return ErrInvalidArgument;
+            }
+
+            using var stream = new UnmanagedMemoryStream(json, jsonByteLen);
+            tok.LoadTokenizerJson(stream);
+            return Ok;
+        }
+        catch (Exception ex)
+        {
+            SetLastError(ex);
+            return ErrException;
+        }
+    }
+
+    /// <summary>
+    /// Load a vocab.txt (UTF-8 bytes). <paramref name="convertInputToLowercase"/> != 0 enables lowercasing,
+    /// as for uncased models. The caller keeps ownership of the buffer.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "fbt_load_vocab_txt")]
+    public static int LoadVocabTxt(nint handle, byte* vocab, nint vocabByteLen, int convertInputToLowercase)
+    {
+        try
+        {
+            if (Resolve(handle) is not { } tok)
+            {
+                return ErrInvalidHandle;
+            }
+
+            if (vocab is null || vocabByteLen < 0)
+            {
+                _lastError = "vocab must not be null and vocabByteLen must be >= 0.";
+                return ErrInvalidArgument;
+            }
+
+            using var stream = new UnmanagedMemoryStream(vocab, vocabByteLen);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            tok.LoadVocabulary(reader, convertInputToLowercase != 0);
+            return Ok;
+        }
+        catch (Exception ex)
+        {
+            SetLastError(ex);
+            return ErrException;
+        }
+    }
+
+    /// <summary>
+    /// Encode a batch of UTF-8 texts. Writes <c>count * max_tokens</c> int64 values to
+    /// <paramref name="inputIds"/> and <paramref name="attentionMask"/> (row-major, one padded row
+    /// per input). <paramref name="tokenTypeIds"/> may be null; if given it is zero-filled.
+    /// <paramref name="parallel"/> != 0 tokenizes on the .NET thread pool (recommended for large batches).
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "fbt_encode_batch")]
+    public static int EncodeBatch(
+        nint handle,
+        byte** texts,
+        int* textByteLens,
+        int count,
+        int maxTokens,
+        long* inputIds,
+        long* attentionMask,
+        long* tokenTypeIds,
+        int parallel)
+    {
+        try
+        {
+            if (Resolve(handle) is not { } tok)
+            {
+                return ErrInvalidHandle;
+            }
+
+            if (texts is null || textByteLens is null || inputIds is null || attentionMask is null
+                || count < 0 || maxTokens <= 0)
+            {
+                _lastError = "texts, textByteLens, inputIds and attentionMask must not be null; count must be >= 0 and maxTokens > 0.";
+                return ErrInvalidArgument;
+            }
+
+            long totalLen = (long)count * maxTokens;
+            if (totalLen > int.MaxValue)
+            {
+                _lastError = $"count * maxTokens must be <= {int.MaxValue} per call; split the batch.";
+                return ErrInvalidArgument;
+            }
+
+            var inputs = MaterializeStrings(texts, textByteLens, count, parallel != 0);
+
+            if (parallel != 0)
+            {
+                using var idsOwner = new PointerMemoryManager<long>(inputIds, (int)totalLen);
+                using var maskOwner = new PointerMemoryManager<long>(attentionMask, (int)totalLen);
+                tok.Encode(inputs, idsOwner.Memory, maskOwner.Memory, maxTokens);
+            }
+            else
+            {
+                for (var i = 0; i < count; i++)
+                {
+                    var offset = (long)i * maxTokens;
+                    tok.Encode(
+                        inputs[i],
+                        new Span<long>(inputIds + offset, maxTokens),
+                        new Span<long>(attentionMask + offset, maxTokens),
+                        padTo: maxTokens);
+                }
+            }
+
+            if (tokenTypeIds is not null)
+            {
+                new Span<long>(tokenTypeIds, (int)totalLen).Clear();
+            }
+
+            return Ok;
+        }
+        catch (Exception ex)
+        {
+            SetLastError(ex);
+            return ErrException;
+        }
+    }
+
+    /// <summary>
+    /// Encode a single UTF-8 text. Writes up to <paramref name="maxTokens"/> int64 values to
+    /// <paramref name="inputIds"/> and <paramref name="attentionMask"/> (padded to <paramref name="maxTokens"/>).
+    /// Returns the number of non-padding tokens produced, or a negative error code.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "fbt_encode")]
+    public static int EncodeSingle(nint handle, byte* text, int textByteLen, int maxTokens, long* inputIds, long* attentionMask)
+    {
+        try
+        {
+            if (Resolve(handle) is not { } tok)
+            {
+                return ErrInvalidHandle;
+            }
+
+            if (text is null || inputIds is null || attentionMask is null || textByteLen < 0 || maxTokens <= 0)
+            {
+                _lastError = "text, inputIds and attentionMask must not be null; textByteLen must be >= 0 and maxTokens > 0.";
+                return ErrInvalidArgument;
+            }
+
+            var input = Encoding.UTF8.GetString(text, textByteLen);
+            return tok.Encode(
+                input,
+                new Span<long>(inputIds, maxTokens),
+                new Span<long>(attentionMask, maxTokens),
+                padTo: maxTokens);
+        }
+        catch (Exception ex)
+        {
+            SetLastError(ex);
+            return ErrException;
+        }
+    }
+
+    /// <summary>
+    /// Decode token ids back to text. Always writes the required UTF-8 byte count to
+    /// <paramref name="outRequiredByteLen"/>. If <paramref name="outUtf8"/> is non-null and
+    /// <paramref name="outByteLen"/> is large enough, writes the UTF-8 result (no NUL terminator)
+    /// and returns 0; otherwise returns <c>ErrBufferTooSmall</c> (-4) without writing text.
+    /// Call with <paramref name="outUtf8"/> = null to query the required size.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "fbt_decode")]
+    public static int Decode(nint handle, long* tokenIds, int count, byte* outUtf8, long outByteLen, long* outRequiredByteLen)
+    {
+        try
+        {
+            if (Resolve(handle) is not { } tok)
+            {
+                return ErrInvalidHandle;
+            }
+
+            if (tokenIds is null || count < 0 || outRequiredByteLen is null)
+            {
+                _lastError = "tokenIds and outRequiredByteLen must not be null and count must be >= 0.";
+                return ErrInvalidArgument;
+            }
+
+            var decoded = tok.Decode(new ReadOnlySpan<long>(tokenIds, count));
+            var byteCount = Encoding.UTF8.GetByteCount(decoded);
+            *outRequiredByteLen = byteCount;
+            if (outUtf8 is null || outByteLen < byteCount)
+            {
+                return ErrBufferTooSmall;
+            }
+
+            Encoding.UTF8.GetBytes(decoded, new Span<byte>(outUtf8, byteCount));
+            return Ok;
+        }
+        catch (Exception ex)
+        {
+            SetLastError(ex);
+            return ErrException;
+        }
+    }
+
+    /// <summary>
+    /// Returns a NUL-terminated UTF-8 message describing the last error on the calling thread,
+    /// or 0 if none occurred. The pointer stays valid until the next failing call on the same thread.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "fbt_last_error")]
+    public static nint LastError()
+    {
+        var msg = _lastError;
+        if (msg is null)
+        {
+            return 0;
+        }
+
+        if (_lastErrorUtf8 != 0)
+        {
+            NativeMemory.Free((void*)_lastErrorUtf8);
+            _lastErrorUtf8 = 0;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(msg);
+        var buf = (byte*)NativeMemory.Alloc((nuint)bytes.Length + 1);
+        bytes.CopyTo(new Span<byte>(buf, bytes.Length));
+        buf[bytes.Length] = 0;
+        _lastErrorUtf8 = (nint)buf;
+        return _lastErrorUtf8;
+    }
+
+    private static void SetLastError(Exception ex) => _lastError = ex.ToString();
+
+    private static BertTokenizer? Resolve(nint handle)
+    {
+        if (handle == 0)
+        {
+            _lastError = "handle must not be 0.";
+            return null;
+        }
+
+        if (GCHandle.FromIntPtr(handle).Target is BertTokenizer tok)
+        {
+            return tok;
+        }
+
+        _lastError = "handle does not refer to a tokenizer instance.";
+        return null;
+    }
+
+    private static string[] MaterializeStrings(byte** texts, int* textByteLens, int count, bool parallel)
+    {
+        var result = new string[count];
+
+        // Converting UTF-8 to .NET strings is a real share of small-batch runtime, so parallelize
+        // it alongside parallel tokenization. Pointers can't be captured by lambdas; smuggle them
+        // through nints.
+        if (parallel && count >= 256)
+        {
+            var textsAddr = (nint)texts;
+            var lensAddr = (nint)textByteLens;
+            Parallel.For(0, count, i =>
+            {
+                var t = ((byte**)textsAddr)[i];
+                var l = ((int*)lensAddr)[i];
+                result[i] = l == 0 || t is null ? string.Empty : Encoding.UTF8.GetString(t, l);
+            });
+        }
+        else
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var t = texts[i];
+                var l = textByteLens[i];
+                result[i] = l == 0 || t is null ? string.Empty : Encoding.UTF8.GetString(t, l);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>Exposes caller-owned native memory as <see cref="Memory{T}"/> without copying.</summary>
+    private sealed class PointerMemoryManager<T> : MemoryManager<T>
+        where T : unmanaged
+    {
+        private readonly nint _ptr;
+        private readonly int _length;
+
+        public PointerMemoryManager(T* ptr, int length)
+        {
+            _ptr = (nint)ptr;
+            _length = length;
+        }
+
+        public override Span<T> GetSpan() => new((void*)_ptr, _length);
+
+        public override MemoryHandle Pin(int elementIndex = 0) => new((T*)_ptr + elementIndex);
+
+        public override void Unpin()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/FastBertTokenizer.Native/NativeExports.cs
+++ b/src/FastBertTokenizer.Native/NativeExports.cs
@@ -33,6 +33,9 @@ internal static unsafe class NativeExports
     private static string? _lastError;
 
     [ThreadStatic]
+    private static string? _lastErrorMaterialized;
+
+    [ThreadStatic]
     private static nint _lastErrorUtf8;
 
     /// <summary>Create a new tokenizer instance. Returns an opaque handle, or 0 on failure.</summary>
@@ -286,6 +289,14 @@ internal static unsafe class NativeExports
             return 0;
         }
 
+        // Repeated queries must return the same buffer while no new failure occurred - the
+        // documented lifetime is "valid until the next failing call on this thread". Only
+        // re-encode (and free the previous buffer) once the message actually changed.
+        if (_lastErrorUtf8 != 0 && ReferenceEquals(_lastErrorMaterialized, msg))
+        {
+            return _lastErrorUtf8;
+        }
+
         if (_lastErrorUtf8 != 0)
         {
             NativeMemory.Free((void*)_lastErrorUtf8);
@@ -297,6 +308,7 @@ internal static unsafe class NativeExports
         bytes.CopyTo(new Span<byte>(buf, bytes.Length));
         buf[bytes.Length] = 0;
         _lastErrorUtf8 = (nint)buf;
+        _lastErrorMaterialized = msg;
         return _lastErrorUtf8;
     }
 

--- a/src/FastBertTokenizer.Native/NativeExports.cs
+++ b/src/FastBertTokenizer.Native/NativeExports.cs
@@ -246,11 +246,13 @@ internal static unsafe class NativeExports
             }
 
             var input = Encoding.UTF8.GetString(text, textByteLen);
-            return tok.Encode(
-                input,
-                new Span<long>(inputIds, maxTokens),
-                new Span<long>(attentionMask, maxTokens),
-                padTo: maxTokens);
+            var maskSpan = new Span<long>(attentionMask, maxTokens);
+            tok.Encode(input, new Span<long>(inputIds, maxTokens), maskSpan, padTo: maxTokens);
+
+            // With padTo set, Encode returns the padded length; the documented return value is
+            // the non-padding count, which the attention mask (1s followed by 0s) tells us.
+            var nonPadded = maskSpan.IndexOf(0L);
+            return nonPadded < 0 ? maxTokens : nonPadded;
         }
         catch (Exception ex)
         {

--- a/src/FastBertTokenizer.Native/packages.lock.json
+++ b/src/FastBertTokenizer.Native/packages.lock.json
@@ -1,0 +1,79 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g=="
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[10.0.301, )",
+        "resolved": "10.0.301",
+        "contentHash": "S9U9Ye2bylMeDkzdNh+TsbRUNr6rkBORrnXDk45maPIxVvTmHV1SN2/qtZ/6yO7cdWmQv1LHv77yIeG6Q3nvMQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "10.0.301",
+          "Microsoft.SourceLink.Common": "10.0.301",
+          "System.IO.Hashing": "10.0.10"
+        }
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.10.91, )",
+        "resolved": "3.10.91",
+        "contentHash": "9MtEXm/um2lQAEoek1EkF4CXNH4JuXxv2jV3Ew2XlzP0LXxFaFiECS7ji8zf1ZaMnPGYbbom+Nm6y4ADc5HNHQ=="
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Direct",
+        "requested": "[1.2.0.556, )",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "10.0.301",
+        "contentHash": "9Tah8f2BYuXlff9nIsJAeQJcqnijJTXNraIcTOF2f/f9kLmg0HNWPlMemnD6FBLd/UQcE0s9Vze2zCkA6nrZAA==",
+        "dependencies": {
+          "System.IO.Hashing": "10.0.10"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "10.0.301",
+        "contentHash": "oz44EclJdAYVZcRb9dSbWd+6RaE+8a4j5zdE+O7yw5qPRZZhu3pcpDZ/Moy6pLeIXZqBP1FMd8CSE0sgJAGV0g=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "eE839zyWZD/UBZYzP2lu9fhHX6RWe63/jz3Jxf+JumzO/db+Vc2s7CMiDwxk9ti2NTUft2tdRx31Rw2OjKbecA=="
+      },
+      "fastberttokenizer": {
+        "type": "Project"
+      }
+    },
+    "net10.0/linux-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g==",
+        "dependencies": {
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.10"
+        }
+      },
+      "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "WRjSRBfv6A6UjgjO8EQuLe9xqdICpkQx1hACUziCw4B2uGL+2jVhkFLq/G7rxRr3MGvqLo9B+nNdfIJ/5CYN7A=="
+      }
+    }
+  }
+}

--- a/src/FastBertTokenizer.Tests/ParallelEncodeExceptions.cs
+++ b/src/FastBertTokenizer.Tests/ParallelEncodeExceptions.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Georg Jung. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Shouldly;
+
+namespace FastBertTokenizer.Tests;
+
+public class ParallelEncodeExceptions
+{
+    /// <summary>
+    /// Exceptions thrown by the thread pool workers of the parallel batch Encode must propagate
+    /// to the caller. Before this was the case, they were unhandled exceptions on thread pool
+    /// threads and thus terminated the process (especially relevant when FastBertTokenizer is
+    /// embedded in a non-.NET host via FastBertTokenizer.Native).
+    /// </summary>
+    [Fact]
+    public void EncodingParallelWithoutLoadedVocabularyThrows()
+    {
+        var uut = new BertTokenizer();
+        var inputs = Enumerable.Repeat("Lorem ipsum dolor sit amet.", 100).ToArray();
+        var iids = new long[inputs.Length * 128];
+        var attm = new long[inputs.Length * 128];
+        Should.Throw<InvalidOperationException>(() => uut.Encode(inputs, iids, attm, 128));
+    }
+
+    [Fact]
+    public async Task ExceptionInOneWorkerDoesNotHangTheBatch()
+    {
+        var uut = new BertTokenizer();
+        await uut.LoadTokenizerJsonAsync("data/bert-base-uncased/tokenizer.json");
+
+        // maximumTokens: 1 leaves no room to write the trailing [SEP] token, which makes the
+        // encoding workers throw. The call must fail fast instead of deadlocking on the
+        // never-signaled countdown or tearing down the process.
+        var inputs = Enumerable.Repeat("Lorem ipsum dolor sit amet.", 100).ToArray();
+        var iids = new long[inputs.Length];
+        var attm = new long[inputs.Length];
+        var act = () => uut.Encode(inputs, iids, attm, 1);
+        act.ShouldThrow<Exception>();
+    }
+}

--- a/src/FastBertTokenizer/BertTokenizer.Parallel.cs
+++ b/src/FastBertTokenizer/BertTokenizer.Parallel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
 
 namespace FastBertTokenizer;
 
@@ -74,6 +75,7 @@ public partial class BertTokenizer
         }
 
         using var cde = new CountdownEvent(ranges.Length);
+        Exception? exception = null;
         foreach (var range in ranges)
         {
 #if NETSTANDARD2_0
@@ -84,20 +86,35 @@ public partial class BertTokenizer
         }
 
         cde.Wait();
+        if (exception is not null)
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+        }
 
         void ParallelBody((int StartInclusive, int EndExclusive) param)
         {
-            var inputSpan = inputs.Span;
-            for (var i = param.StartInclusive; i < param.EndExclusive; i++)
+            // An exception escaping a ThreadPool.QueueUserWorkItem callback terminates the
+            // process, so capture it (first one wins) and rethrow on the calling thread.
+            try
             {
-                var startIdx = maximumTokens * i;
-                var (_, nonPad) = Encode(inputSpan[i], 0, inputIds.Slice(startIdx, maximumTokens).Span, out var _, maximumTokens);
-                var span = attentionMask.Slice(startIdx, maximumTokens).Span;
-                span.Slice(0, nonPad).Fill(1);
-                span.Slice(nonPad, maximumTokens - nonPad).Fill(0);
+                var inputSpan = inputs.Span;
+                for (var i = param.StartInclusive; i < param.EndExclusive; i++)
+                {
+                    var startIdx = maximumTokens * i;
+                    var (_, nonPad) = Encode(inputSpan[i], 0, inputIds.Slice(startIdx, maximumTokens).Span, out var _, maximumTokens);
+                    var span = attentionMask.Slice(startIdx, maximumTokens).Span;
+                    span.Slice(0, nonPad).Fill(1);
+                    span.Slice(nonPad, maximumTokens - nonPad).Fill(0);
+                }
             }
-
-            cde.Signal();
+            catch (Exception ex)
+            {
+                Interlocked.CompareExchange(ref exception, ex, null);
+            }
+            finally
+            {
+                cde.Signal();
+            }
         }
 
 #if NETSTANDARD2_0

--- a/src/PythonBinding/README.md
+++ b/src/PythonBinding/README.md
@@ -38,8 +38,19 @@ Result: 3 of 15,000 documents (0.02 %) differ — the same known corpus-level di
 
 [`bench.py`](bench.py) mirrors the methodology of
 [`../HuggingfaceTokenizer/BenchPython/bench.py`](../HuggingfaceTokenizer/BenchPython/bench.py)
-(same corpus, same vocabulary, truncation at 512 tokens, pyperf). Numbers depend on the
-machine; see the PR / CI logs for measured results.
+(same corpus, same vocabulary, truncation at 512 tokens, pyperf). Measured in a 4-vCPU
+Linux x64 container (`pyperf --fast`, so treat as indicative rather than rigorous):
+
+| Called from Python                  | Single-text loop | Batch (parallel) |
+|-------------------------------------|-----------------:|-----------------:|
+| **FastBertTokenizer (this binding)**|       **542 ms** |       **211 ms** |
+| tokie (Rust)                        |          1.11 s  |           830 ms |
+| Hugging Face tokenizers (Rust)      |          11.0 s  |           3.01 s |
+
+FastBertTokenizer's batch call additionally ran at 531 ms with `parallel=False`. At ~3.66 M
+tokens for the corpus, 211 ms is ≈17 M tokens/s from Python — including the Python → native
+UTF-8 marshalling and numpy allocation, i.e. the interop cost does not eat the library's
+advantage.
 
 ## What a real release would still need
 

--- a/src/PythonBinding/README.md
+++ b/src/PythonBinding/README.md
@@ -28,6 +28,10 @@ tokenization uses all cores via the .NET thread pool.
 
 ## Correctness
 
+[`smoke.py`](smoke.py) exercises the C ABI contract itself: handle lifecycle (including
+stale/garbage/double-destroyed handles), error codes and last-error semantics, encode
+return values, per-item argument validation and the decode size-query protocol.
+
 [`verify.py`](verify.py) checks id-level parity against Hugging Face `tokenizers` on the
 benchmark corpus (15,000 simple english wikipedia articles), analogous to
 [`../HuggingfaceTokenizer/BenchPython/verify.py`](../HuggingfaceTokenizer/BenchPython/verify.py).

--- a/src/PythonBinding/README.md
+++ b/src/PythonBinding/README.md
@@ -1,0 +1,54 @@
+# FastBertTokenizer from Python (prototype)
+
+A prototype Python binding for FastBertTokenizer. Instead of re-implementing the tokenizer,
+the existing .NET library is compiled to a self-contained native shared library with
+[NativeAOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) — no .NET runtime
+required at run time — and consumed from Python via `ctypes` + numpy. The exported C ABI lives
+in [`../FastBertTokenizer.Native`](../FastBertTokenizer.Native).
+
+```bash
+# 1. Build the native library (once per platform; needs the .NET SDK + clang on Linux/macOS)
+dotnet publish ../FastBertTokenizer.Native -c Release -r linux-x64   # or osx-arm64, win-x64, ...
+
+# 2. Use it
+pip install numpy
+python -c "
+from fastberttokenizer import BertTokenizer
+tok = BertTokenizer.from_tokenizer_json('../../data/baai-bge-small-en/tokenizer.json')
+input_ids, attention_mask = tok.encode_batch(['Lorem ipsum dolor sit amet.'], max_tokens=512)
+print(input_ids[0][:12])
+print(tok.decode(input_ids[0][attention_mask[0] == 1]))
+"
+```
+
+`encode_batch` writes directly into pre-allocated numpy `int64` arrays of shape
+`(len(texts), max_tokens)` — the exact layout models expect — so there is no per-document
+Python object overhead. ctypes releases the GIL during the native call; with `parallel=True`
+tokenization uses all cores via the .NET thread pool.
+
+## Correctness
+
+[`verify.py`](verify.py) checks id-level parity against Hugging Face `tokenizers` on the
+benchmark corpus (15,000 simple english wikipedia articles), analogous to
+[`../HuggingfaceTokenizer/BenchPython/verify.py`](../HuggingfaceTokenizer/BenchPython/verify.py).
+Result: 3 of 15,000 documents (0.02 %) differ — the same known corpus-level differences the
+.NET library itself has, i.e. the binding adds no drift.
+
+## Speed
+
+[`bench.py`](bench.py) mirrors the methodology of
+[`../HuggingfaceTokenizer/BenchPython/bench.py`](../HuggingfaceTokenizer/BenchPython/bench.py)
+(same corpus, same vocabulary, truncation at 512 tokens, pyperf). Numbers depend on the
+machine; see the PR / CI logs for measured results.
+
+## What a real release would still need
+
+* **Wheel packaging**: bundle the published native library per platform
+  (`manylinux`/`musllinux` x64+arm64, macOS universal, Windows x64) into platform wheels.
+  No compiler needed at `pip install` time — wheels just repackage the AOT binaries.
+* **ICU**: NativeAOT loads ICU dynamically for Unicode normalization/casing. Manylinux does
+  not guarantee libicu, so wheels should either link ICU statically
+  (`StaticICULinking=true`) or ship app-local ICU.
+* **API polish**: streaming/`overflowing` batch APIs (`CreateBatchEnumerator`), loading from
+  the Hugging Face Hub (best done in Python via `huggingface_hub`), and a `cffi`/HPy layer if
+  ctypes overhead ever becomes measurable (it is negligible for batch calls).

--- a/src/PythonBinding/bench.py
+++ b/src/PythonBinding/bench.py
@@ -1,0 +1,95 @@
+# Copyright (c) Georg Jung. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Benchmarks the FastBertTokenizer Python binding against Hugging Face tokenizers and tokie,
+# measured from Python the way a Python user would call them. Uses the same corpus (simple
+# english wikipedia), vocabulary (baai-bge-small-en) and methodology as
+# ../HuggingfaceTokenizer/BenchPython/bench.py, so numbers are comparable.
+#
+#   dotnet publish ../FastBertTokenizer.Native -c Release -r linux-x64
+#   pip install numpy tokenizers tokie pyperf
+#   python bench.py
+#
+# pyperf runs each benchmark in fresh worker processes; pass e.g. --fast to reduce runtime.
+
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CORPUS = str(REPO_ROOT / "data" / "wiki-simple.json")
+TOKENIZER_JSON = str(REPO_ROOT / "data" / "baai-bge-small-en" / "tokenizer.json")
+MAX_LENGTH = 512
+PKG_DIR = str(pathlib.Path(__file__).resolve().parent)
+
+SETUP_CORPUS = f"""
+import json
+with open({CORPUS!r}, encoding="utf-8") as f:
+    corpus = list(json.load(f).values())
+"""
+
+SETUP_FBT = f"""
+import sys
+sys.path.insert(0, {PKG_DIR!r})
+""" + SETUP_CORPUS + f"""
+from fastberttokenizer import BertTokenizer
+tok = BertTokenizer.from_tokenizer_json({TOKENIZER_JSON!r})
+"""
+
+SETUP_HF = SETUP_CORPUS + f"""
+from tokenizers import Tokenizer
+tok = Tokenizer.from_file({TOKENIZER_JSON!r})
+tok.enable_truncation(max_length={MAX_LENGTH})
+"""
+
+SETUP_TOKIE = SETUP_CORPUS + f"""
+from tokie import Tokenizer
+tok = Tokenizer.from_json({TOKENIZER_JSON!r})
+tok.enable_truncation({MAX_LENGTH})
+"""
+
+if __name__ == "__main__":
+    import pyperf
+
+    runner = pyperf.Runner()
+
+    # Single-text loops: one Python -> native call per document, including each library's
+    # per-call overhead. All effectively single-threaded except possibly tokie (see
+    # BenchPython/bench.py for the caveat).
+    runner.timeit(
+        name="fbt_singlethreaded",
+        stmt=f"for text in corpus:\n    tok.encode(text, max_tokens={MAX_LENGTH})",
+        setup=SETUP_FBT,
+    )
+    runner.timeit(
+        name="hf_tokenizers_singlethreaded",
+        stmt="for text in corpus:\n    tok.encode(text)",
+        setup=SETUP_HF,
+    )
+    runner.timeit(
+        name="tokie_sequential_calls",
+        stmt="for text in corpus:\n    tok.encode(text)",
+        setup=SETUP_TOKIE,
+    )
+
+    # Batch mode: one call for the whole corpus, each library parallelizing natively.
+    # fbt returns padded (n, 512) int64 numpy arrays for input_ids and attention_mask —
+    # ready for model consumption — while hf/tokie return per-document Encoding objects.
+    runner.timeit(
+        name="fbt_batch",
+        stmt=f"tok.encode_batch(corpus, max_tokens={MAX_LENGTH}, parallel=True)",
+        setup=SETUP_FBT,
+    )
+    runner.timeit(
+        name="fbt_batch_singlethreaded",
+        stmt=f"tok.encode_batch(corpus, max_tokens={MAX_LENGTH}, parallel=False)",
+        setup=SETUP_FBT,
+    )
+    runner.timeit(
+        name="hf_tokenizers_batch",
+        stmt="tok.encode_batch(corpus)",
+        setup=SETUP_HF,
+    )
+    runner.timeit(
+        name="tokie_batch",
+        stmt="tok.encode_batch(corpus)",
+        setup=SETUP_TOKIE,
+    )

--- a/src/PythonBinding/fastberttokenizer/__init__.py
+++ b/src/PythonBinding/fastberttokenizer/__init__.py
@@ -35,6 +35,13 @@ class NativeError(RuntimeError):
     """An error reported by the FastBertTokenizer native library."""
 
 
+def _validate_max_tokens(max_tokens: int) -> None:
+    if max_tokens <= 0:
+        raise ValueError("max_tokens must be > 0.")
+    if max_tokens > 2**31 - 1:
+        raise ValueError(f"max_tokens must be <= {2**31 - 1}.")
+
+
 def _default_lib_names() -> list[str]:
     system = platform.system()
     if system == "Windows":
@@ -171,8 +178,7 @@ class BertTokenizer:
         padded per row. The arrays can be fed directly to e.g. onnxruntime or torch.
         """
         count = len(texts)
-        if max_tokens <= 0:
-            raise ValueError("max_tokens must be > 0.")
+        _validate_max_tokens(max_tokens)
         # The native side rejects batches larger than this anyway; failing here avoids
         # allocating the (potentially huge) output arrays first.
         if count * max_tokens > 2**31 - 1:
@@ -210,9 +216,12 @@ class BertTokenizer:
 
     def encode(self, text: str, max_tokens: int = 512):
         """Encode a single text. Returns (input_ids, attention_mask) as 1-D numpy int64 arrays."""
+        _validate_max_tokens(max_tokens)
+        data = text.encode("utf-8")
+        if len(data) > 2**31 - 1:
+            raise ValueError("a single text must not exceed 2 GiB of UTF-8 bytes.")
         input_ids = np.empty(max_tokens, dtype=np.int64)
         attention_mask = np.empty(max_tokens, dtype=np.int64)
-        data = text.encode("utf-8")
         int64_ptr = ctypes.POINTER(ctypes.c_int64)
         rc = self._lib.fbt_encode(
             self._handle,

--- a/src/PythonBinding/fastberttokenizer/__init__.py
+++ b/src/PythonBinding/fastberttokenizer/__init__.py
@@ -171,11 +171,22 @@ class BertTokenizer:
         padded per row. The arrays can be fed directly to e.g. onnxruntime or torch.
         """
         count = len(texts)
+        if max_tokens <= 0:
+            raise ValueError("max_tokens must be > 0.")
+        # The native side rejects batches larger than this anyway; failing here avoids
+        # allocating the (potentially huge) output arrays first.
+        if count * max_tokens > 2**31 - 1:
+            raise ValueError(
+                f"count * max_tokens must be <= {2**31 - 1} per call; split the batch."
+            )
+
+        encoded = [t.encode("utf-8") for t in texts]
+        if encoded and max(map(len, encoded)) > 2**31 - 1:
+            raise ValueError("a single text must not exceed 2 GiB of UTF-8 bytes.")
+
         input_ids = np.empty((count, max_tokens), dtype=np.int64)
         attention_mask = np.empty((count, max_tokens), dtype=np.int64)
         token_type_ids = np.empty((count, max_tokens), dtype=np.int64) if return_token_type_ids else None
-
-        encoded = [t.encode("utf-8") for t in texts]
         text_array = (ctypes.c_char_p * count)(*encoded)
         len_array = (ctypes.c_int32 * count)(*(len(b) for b in encoded))
 

--- a/src/PythonBinding/fastberttokenizer/__init__.py
+++ b/src/PythonBinding/fastberttokenizer/__init__.py
@@ -1,0 +1,260 @@
+# Copyright (c) Georg Jung. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""Python binding for FastBertTokenizer via its NativeAOT-compiled C ABI.
+
+Prototype status: loads the shared library produced by
+``dotnet publish src/FastBertTokenizer.Native -c Release -r <rid>`` and exposes
+batch encoding into numpy arrays, single-text encoding, and decoding.
+
+The heavy lifting happens outside the GIL (ctypes releases it for the duration
+of the native call), so ``encode_batch(..., parallel=True)`` uses all cores.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import pathlib
+import platform
+from typing import Sequence
+
+import numpy as np
+
+__all__ = ["BertTokenizer", "NativeError"]
+
+_ERROR_CODES = {
+    -1: "exception in native code",
+    -2: "invalid handle",
+    -3: "invalid argument",
+    -4: "buffer too small",
+}
+
+
+class NativeError(RuntimeError):
+    """An error reported by the FastBertTokenizer native library."""
+
+
+def _default_lib_names() -> list[str]:
+    system = platform.system()
+    if system == "Windows":
+        return ["FastBertTokenizer.Native.dll"]
+    if system == "Darwin":
+        return ["FastBertTokenizer.Native.dylib"]
+    return ["FastBertTokenizer.Native.so"]
+
+
+def _default_rid() -> str:
+    system = platform.system()
+    machine = platform.machine().lower()
+    arch = {"x86_64": "x64", "amd64": "x64", "aarch64": "arm64", "arm64": "arm64"}.get(machine, machine)
+    osname = {"Windows": "win", "Darwin": "osx"}.get(system, "linux")
+    return f"{osname}-{arch}"
+
+
+def _find_library() -> str:
+    override = os.environ.get("FBT_NATIVE_LIB")
+    if override:
+        if os.path.isfile(override):
+            return override
+        raise FileNotFoundError(f"FBT_NATIVE_LIB points to {override!r}, which does not exist.")
+
+    names = _default_lib_names()
+    pkg_dir = pathlib.Path(__file__).resolve().parent
+    # In a built wheel the native lib would ship inside the package; during repo-local
+    # development we fall back to the dotnet publish output.
+    repo_root = pkg_dir.parents[2]
+    publish_dir = (
+        repo_root / "bin" / "FastBertTokenizer.Native" / "Release" / "net10.0" / _default_rid() / "publish"
+    )
+    candidates = [pkg_dir / n for n in names] + [publish_dir / n for n in names]
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    raise FileNotFoundError(
+        "FastBertTokenizer native library not found. Looked for "
+        + ", ".join(str(c) for c in candidates)
+        + ". Build it with: dotnet publish src/FastBertTokenizer.Native -c Release -r "
+        + _default_rid()
+    )
+
+
+def _load(lib_path: str | None) -> ctypes.CDLL:
+    lib = ctypes.CDLL(lib_path or _find_library())
+
+    lib.fbt_create.restype = ctypes.c_void_p
+    lib.fbt_create.argtypes = []
+    lib.fbt_destroy.restype = None
+    lib.fbt_destroy.argtypes = [ctypes.c_void_p]
+    lib.fbt_last_error.restype = ctypes.c_char_p
+    lib.fbt_last_error.argtypes = []
+    lib.fbt_load_tokenizer_json.restype = ctypes.c_int32
+    lib.fbt_load_tokenizer_json.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_ssize_t]
+    lib.fbt_load_vocab_txt.restype = ctypes.c_int32
+    lib.fbt_load_vocab_txt.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_ssize_t, ctypes.c_int32]
+    lib.fbt_encode_batch.restype = ctypes.c_int32
+    lib.fbt_encode_batch.argtypes = [
+        ctypes.c_void_p,                    # handle
+        ctypes.POINTER(ctypes.c_char_p),    # texts
+        ctypes.POINTER(ctypes.c_int32),     # text byte lens
+        ctypes.c_int32,                     # count
+        ctypes.c_int32,                     # max_tokens
+        ctypes.POINTER(ctypes.c_int64),     # input_ids out
+        ctypes.POINTER(ctypes.c_int64),     # attention_mask out
+        ctypes.POINTER(ctypes.c_int64),     # token_type_ids out (nullable)
+        ctypes.c_int32,                     # parallel
+    ]
+    lib.fbt_encode.restype = ctypes.c_int32
+    lib.fbt_encode.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_int32,
+        ctypes.c_int32,
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.POINTER(ctypes.c_int64),
+    ]
+    lib.fbt_decode.restype = ctypes.c_int32
+    lib.fbt_decode.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.c_int32,
+        ctypes.c_char_p,
+        ctypes.c_int64,
+        ctypes.POINTER(ctypes.c_int64),
+    ]
+    return lib
+
+
+class BertTokenizer:
+    """WordPiece/BERT tokenizer backed by FastBertTokenizer's native library."""
+
+    def __init__(self, lib_path: str | None = None) -> None:
+        self._lib = _load(lib_path)
+        handle = self._lib.fbt_create()
+        if not handle:
+            self._raise("fbt_create")
+        self._handle = handle
+
+    @classmethod
+    def from_tokenizer_json(cls, path: str | os.PathLike, lib_path: str | None = None) -> "BertTokenizer":
+        """Create a tokenizer from a Hugging Face tokenizer.json file."""
+        self = cls(lib_path)
+        data = pathlib.Path(path).read_bytes()
+        rc = self._lib.fbt_load_tokenizer_json(self._handle, data, len(data))
+        if rc != 0:
+            self._raise("fbt_load_tokenizer_json", rc)
+        return self
+
+    @classmethod
+    def from_vocab_txt(
+        cls, path: str | os.PathLike, lowercase: bool = True, lib_path: str | None = None
+    ) -> "BertTokenizer":
+        """Create a tokenizer from a vocab.txt file, as for bert-base-uncased with lowercase=True."""
+        self = cls(lib_path)
+        data = pathlib.Path(path).read_bytes()
+        rc = self._lib.fbt_load_vocab_txt(self._handle, data, len(data), 1 if lowercase else 0)
+        if rc != 0:
+            self._raise("fbt_load_vocab_txt", rc)
+        return self
+
+    def encode_batch(
+        self,
+        texts: Sequence[str],
+        max_tokens: int = 512,
+        parallel: bool = True,
+        return_token_type_ids: bool = False,
+    ):
+        """Encode a batch of texts.
+
+        Returns (input_ids, attention_mask) — or (input_ids, attention_mask, token_type_ids)
+        if return_token_type_ids is set — as numpy int64 arrays of shape (len(texts), max_tokens),
+        padded per row. The arrays can be fed directly to e.g. onnxruntime or torch.
+        """
+        count = len(texts)
+        input_ids = np.empty((count, max_tokens), dtype=np.int64)
+        attention_mask = np.empty((count, max_tokens), dtype=np.int64)
+        token_type_ids = np.empty((count, max_tokens), dtype=np.int64) if return_token_type_ids else None
+
+        encoded = [t.encode("utf-8") for t in texts]
+        text_array = (ctypes.c_char_p * count)(*encoded)
+        len_array = (ctypes.c_int32 * count)(*(len(b) for b in encoded))
+
+        int64_ptr = ctypes.POINTER(ctypes.c_int64)
+        rc = self._lib.fbt_encode_batch(
+            self._handle,
+            text_array,
+            len_array,
+            count,
+            max_tokens,
+            input_ids.ctypes.data_as(int64_ptr),
+            attention_mask.ctypes.data_as(int64_ptr),
+            token_type_ids.ctypes.data_as(int64_ptr) if token_type_ids is not None else None,
+            1 if parallel else 0,
+        )
+        if rc != 0:
+            self._raise("fbt_encode_batch", rc)
+        if token_type_ids is not None:
+            return input_ids, attention_mask, token_type_ids
+        return input_ids, attention_mask
+
+    def encode(self, text: str, max_tokens: int = 512):
+        """Encode a single text. Returns (input_ids, attention_mask) as 1-D numpy int64 arrays."""
+        input_ids = np.empty(max_tokens, dtype=np.int64)
+        attention_mask = np.empty(max_tokens, dtype=np.int64)
+        data = text.encode("utf-8")
+        int64_ptr = ctypes.POINTER(ctypes.c_int64)
+        rc = self._lib.fbt_encode(
+            self._handle,
+            data,
+            len(data),
+            max_tokens,
+            input_ids.ctypes.data_as(int64_ptr),
+            attention_mask.ctypes.data_as(int64_ptr),
+        )
+        if rc < 0:
+            self._raise("fbt_encode", rc)
+        return input_ids, attention_mask
+
+    def decode(self, token_ids) -> str:
+        """Decode token ids (any int sequence or numpy array) back to text."""
+        ids = np.ascontiguousarray(token_ids, dtype=np.int64)
+        int64_ptr = ctypes.POINTER(ctypes.c_int64)
+        required = ctypes.c_int64()
+        rc = self._lib.fbt_decode(
+            self._handle, ids.ctypes.data_as(int64_ptr), ids.size, None, 0, ctypes.byref(required)
+        )
+        if rc == 0:
+            return ""
+        if rc != -4:  # anything but "buffer too small" is a real error
+            self._raise("fbt_decode", rc)
+        buf = ctypes.create_string_buffer(required.value)
+        rc = self._lib.fbt_decode(
+            self._handle, ids.ctypes.data_as(int64_ptr), ids.size, buf, required.value, ctypes.byref(required)
+        )
+        if rc != 0:
+            self._raise("fbt_decode", rc)
+        return buf.raw[: required.value].decode("utf-8")
+
+    def close(self) -> None:
+        """Free the native tokenizer. The object must not be used afterwards."""
+        if getattr(self, "_handle", None):
+            self._lib.fbt_destroy(self._handle)
+            self._handle = None
+
+    def __enter__(self) -> "BertTokenizer":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def _raise(self, func: str, rc: int | None = None):
+        msg = self._lib.fbt_last_error()
+        detail = msg.decode("utf-8", errors="replace") if msg else "unknown error"
+        code = f" ({_ERROR_CODES.get(rc, rc)})" if rc is not None else ""
+        raise NativeError(f"{func} failed{code}: {detail}")

--- a/src/PythonBinding/fastberttokenizer/__init__.py
+++ b/src/PythonBinding/fastberttokenizer/__init__.py
@@ -220,13 +220,15 @@ class BertTokenizer:
         ids = np.ascontiguousarray(token_ids, dtype=np.int64)
         int64_ptr = ctypes.POINTER(ctypes.c_int64)
         required = ctypes.c_int64()
+        # Size query: the native side always answers -4 ("buffer too small") for a null
+        # output buffer and reports the required byte count via `required`.
         rc = self._lib.fbt_decode(
             self._handle, ids.ctypes.data_as(int64_ptr), ids.size, None, 0, ctypes.byref(required)
         )
-        if rc == 0:
-            return ""
-        if rc != -4:  # anything but "buffer too small" is a real error
+        if rc != -4:
             self._raise("fbt_decode", rc)
+        if required.value == 0:
+            return ""
         buf = ctypes.create_string_buffer(required.value)
         rc = self._lib.fbt_decode(
             self._handle, ids.ctypes.data_as(int64_ptr), ids.size, buf, required.value, ctypes.byref(required)

--- a/src/PythonBinding/smoke.py
+++ b/src/PythonBinding/smoke.py
@@ -1,0 +1,123 @@
+# Copyright (c) Georg Jung. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Smoke tests for the FastBertTokenizer.Native C ABI contract, exercised through ctypes:
+# handle lifecycle, error codes, last-error semantics, encode/decode buffer conventions.
+# Complements verify.py (corpus-level correctness) - this checks the ABI itself.
+#
+#   dotnet publish ../FastBertTokenizer.Native -c Release -r linux-x64
+#   pip install numpy
+#   python smoke.py
+
+import ctypes
+import pathlib
+import sys
+
+import numpy as np
+
+from fastberttokenizer import BertTokenizer, NativeError
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOKENIZER_JSON = REPO_ROOT / "data" / "baai-bge-small-en" / "tokenizer.json"
+
+OK = 0
+ERR_EXCEPTION = -1
+ERR_INVALID_HANDLE = -2
+ERR_INVALID_ARGUMENT = -3
+ERR_BUFFER_TOO_SMALL = -4
+
+failures = []
+
+
+def check(name, condition, detail=""):
+    status = "ok" if condition else "FAIL"
+    print(f"  {status}: {name}" + (f" ({detail})" if detail and not condition else ""))
+    if not condition:
+        failures.append(name)
+
+
+def int64_ptr(arr):
+    return arr.ctypes.data_as(ctypes.POINTER(ctypes.c_int64))
+
+
+tok = BertTokenizer.from_tokenizer_json(TOKENIZER_JSON)
+lib = tok._lib
+ids = np.empty(8, dtype=np.int64)
+mask = np.empty(8, dtype=np.int64)
+
+print("handle lifecycle:")
+check("create returns non-zero handle", tok._handle != 0)
+check("zero handle -> invalid handle", lib.fbt_encode(0, b"x", 1, 8, int64_ptr(ids), int64_ptr(mask)) == ERR_INVALID_HANDLE)
+check("garbage handle -> invalid handle", lib.fbt_encode(987654321, b"x", 1, 8, int64_ptr(ids), int64_ptr(mask)) == ERR_INVALID_HANDLE)
+stale = lib.fbt_create()
+lib.fbt_destroy(stale)
+lib.fbt_destroy(stale)  # double destroy must be survivable
+check("stale handle after destroy -> invalid handle", lib.fbt_encode(stale, b"x", 1, 8, int64_ptr(ids), int64_ptr(mask)) == ERR_INVALID_HANDLE)
+
+print("loading:")
+unloaded = lib.fbt_create()
+rc = lib.fbt_load_tokenizer_json(unloaded, b"{ not json", 10)
+check("bad tokenizer.json -> exception code", rc == ERR_EXCEPTION)
+check("error message available", bool(lib.fbt_last_error()))
+big_ids = np.empty((4, 128), dtype=np.int64)
+big_mask = np.empty((4, 128), dtype=np.int64)
+texts = (ctypes.c_char_p * 4)(b"a", b"b", b"c", b"d")
+lens = (ctypes.c_int32 * 4)(1, 1, 1, 1)
+rc = lib.fbt_encode_batch(unloaded, texts, lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), None, 1)
+check("parallel encode without vocabulary -> error, process survives", rc == ERR_EXCEPTION)
+lib.fbt_destroy(unloaded)
+
+print("encode:")
+rc = lib.fbt_encode(tok._handle, b"hi", 2, 8, int64_ptr(ids), int64_ptr(mask))
+check("returns non-padding count", rc == 3, f"got {rc}")
+check("attention mask matches count", int(mask.sum()) == 3)
+long_text = ("lorem ipsum dolor " * 20).encode()
+rc = lib.fbt_encode(tok._handle, long_text, len(long_text), 8, int64_ptr(ids), int64_ptr(mask))
+check("truncated input returns max_tokens", rc == 8, f"got {rc}")
+
+print("encode_batch argument validation:")
+bad_lens = (ctypes.c_int32 * 4)(1, -1, 1, 1)
+rc = lib.fbt_encode_batch(tok._handle, texts, bad_lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), None, 0)
+check("negative per-item length -> invalid argument", rc == ERR_INVALID_ARGUMENT)
+null_texts = (ctypes.c_char_p * 1)(None)
+one_len = (ctypes.c_int32 * 1)(3)
+rc = lib.fbt_encode_batch(tok._handle, null_texts, one_len, 1, 128, int64_ptr(big_ids), int64_ptr(big_mask), None, 0)
+check("null text with positive length -> invalid argument", rc == ERR_INVALID_ARGUMENT)
+rc = lib.fbt_encode_batch(tok._handle, None, lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), None, 0)
+check("null texts array -> invalid argument", rc == ERR_INVALID_ARGUMENT)
+
+print("decode:")
+lib.fbt_encode(tok._handle, b"hi", 2, 8, int64_ptr(ids), int64_ptr(mask))
+required = ctypes.c_int64()
+rc = lib.fbt_decode(tok._handle, int64_ptr(ids), 3, None, 0, ctypes.byref(required))
+check("size query -> buffer too small + required size", rc == ERR_BUFFER_TOO_SMALL and required.value > 0)
+buf = ctypes.create_string_buffer(required.value)
+rc = lib.fbt_decode(tok._handle, int64_ptr(ids), 3, buf, required.value, ctypes.byref(required))
+check("decode roundtrip", rc == OK and buf.raw[: required.value].decode() == "[CLS] hi [SEP]")
+rc = lib.fbt_decode(tok._handle, int64_ptr(ids), 3, buf, -1, ctypes.byref(required))
+check("negative outByteLen -> invalid argument", rc == ERR_INVALID_ARGUMENT)
+check("wrapper empty decode", tok.decode([]) == "")
+
+print("last_error semantics:")
+lib.fbt_encode(0, b"x", 1, 8, int64_ptr(ids), int64_ptr(mask))  # provoke a failure
+lib.fbt_last_error.restype = ctypes.c_void_p  # compare pointers, not bytes
+p1, p2 = lib.fbt_last_error(), lib.fbt_last_error()
+lib.fbt_last_error.restype = ctypes.c_char_p
+check("pointer stable while no new failure", p1 == p2)
+
+print("wrapper-level errors:")
+try:
+    BertTokenizer().encode_batch(["x"], max_tokens=512)
+    check("unloaded wrapper raises NativeError", False)
+except NativeError:
+    check("unloaded wrapper raises NativeError", True)
+try:
+    tok.encode_batch(["x"], max_tokens=0)
+    check("max_tokens=0 raises ValueError", False)
+except ValueError:
+    check("max_tokens=0 raises ValueError", True)
+
+if failures:
+    print(f"\nFAIL: {len(failures)} check(s) failed: {failures}")
+    sys.exit(1)
+print("\nOK: all ABI smoke tests passed")

--- a/src/PythonBinding/verify.py
+++ b/src/PythonBinding/verify.py
@@ -1,0 +1,54 @@
+# Copyright (c) Georg Jung. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Checks id-level parity of the FastBertTokenizer Python binding against Hugging Face tokenizers
+# on the benchmark corpus — the same check BenchPython/verify.py does for flash-tokenizer/tokie.
+#
+#   dotnet publish ../FastBertTokenizer.Native -c Release -r linux-x64
+#   pip install numpy tokenizers
+#   python verify.py
+
+import json
+import pathlib
+import sys
+
+from tokenizers import Tokenizer
+
+from fastberttokenizer import BertTokenizer
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CORPUS = REPO_ROOT / "data" / "wiki-simple.json"
+TOKENIZER_JSON = REPO_ROOT / "data" / "baai-bge-small-en" / "tokenizer.json"
+MAX_LENGTH = 512
+MAX_MISMATCH_RATE = 0.001
+
+with open(CORPUS, encoding="utf-8") as f:
+    corpus = list(json.load(f).values())
+
+hf = Tokenizer.from_file(str(TOKENIZER_JSON))
+hf.enable_truncation(max_length=MAX_LENGTH)
+hf_ids = [enc.ids for enc in hf.encode_batch(corpus)]
+
+fbt = BertTokenizer.from_tokenizer_json(TOKENIZER_JSON)
+ids, mask = fbt.encode_batch(corpus, max_tokens=MAX_LENGTH, parallel=True)
+
+mismatches = 0
+for i, expected in enumerate(hf_ids):
+    actual = ids[i, : int(mask[i].sum())].tolist()
+    if actual != expected:
+        mismatches += 1
+        if mismatches <= 3:
+            print(f"mismatch in doc {i}:")
+            print(f"  hf : {expected[:30]}")
+            print(f"  fbt: {actual[:30]}")
+
+rate = mismatches / len(corpus)
+print(f"documents:                  {len(corpus)}")
+print(f"total tokens (hf):          {sum(len(x) for x in hf_ids)}")
+print(f"total tokens (fbt):         {int(mask.sum())}")
+print(f"docs with id mismatch:      {mismatches} ({rate:.2%})")
+
+if rate > MAX_MISMATCH_RATE:
+    print(f"FAIL: mismatch rate exceeds the expected maximum of {MAX_MISMATCH_RATE:.2%}")
+    sys.exit(1)
+print("OK")


### PR DESCRIPTION
## What

A working prototype of the "make FastBertTokenizer available to Python consumers" path we discussed: compile the existing .NET library to a self-contained native shared library with **NativeAOT** (no .NET runtime needed at run time, no Rust re-implementation) and consume it from Python via **ctypes + numpy**.

* **`src/FastBertTokenizer.Native`** — flat C ABI over `BertTokenizer` using `[UnmanagedCallersOnly]`: `fbt_create`/`fbt_destroy`, `fbt_load_tokenizer_json`/`fbt_load_vocab_txt` (from bytes), `fbt_encode_batch`/`fbt_encode` (write into caller-provided int64 buffers, row-major `(count, max_tokens)` — exactly numpy's C-contiguous layout), `fbt_decode`, `fbt_last_error` (per-thread). All exceptions are caught at the boundary and surfaced as error codes + message.
  `dotnet publish -c Release -r linux-x64` produces a **~2.9 MB `.so`** that links only libc/libm.
* **`src/PythonBinding`** — `fastberttokenizer` Python package (ctypes): `BertTokenizer.from_tokenizer_json(...)`, `encode_batch(texts, max_tokens=512, parallel=True)` returning model-ready numpy arrays, `encode`, `decode`, context-manager lifetime. ctypes releases the GIL during the native call, so `parallel=True` uses all cores via the .NET thread pool.
* **`verify.py`** — id-level parity vs Hugging Face `tokenizers` on the in-repo 15k-article corpus (same check BenchPython does for flash-tokenizer/tokie).
* **`bench.py`** — pyperf benchmark mirroring `src/HuggingfaceTokenizer/BenchPython/bench.py` (same corpus, baai-bge-small-en vocab, 512-token truncation) against HF `tokenizers` and tokie.

The native project is intentionally **not** added to the solution/CI yet (like the AOT compatibility test app, it's exercised separately) and nothing about the existing library changes.

## Correctness

`verify.py` on the 15k-article corpus: **3 of 15,000 documents (0.02 %) differ** from HF `tokenizers`, first divergence deep in each document — the same known corpus-level differences the .NET library itself has. The binding adds no drift (total token count differs by 1 across 3.66 M tokens).

## Speed

Benchmark results from this environment are being finalized and will be posted as a comment (the container has 4 vCPUs, comparable to the CI runners used for the README's market overview).

## What a real release would still need

* Platform wheel packaging (manylinux/musllinux x64+arm64, macOS, Windows) — pure repackaging of AOT binaries, no compiler at install time.
* ICU strategy for wheels: NativeAOT dlopens libicu for normalization/casing; manylinux doesn't guarantee it → `StaticICULinking=true` or app-local ICU.
* Publish matrix in CI, smoke tests for the ABI, and a decision on distribution (PyPI name, versioning coupled to the NuGet package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrKqnzxqpno4nh43EbF8eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrKqnzxqpno4nh43EbF8eg)_