### PR TITLE
Group Dependabot version updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,60 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  groups:
+    nuget:
+      # One PR for all non-breaking NuGet updates; majors stay separate.
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: daily
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: "docker"
-  directory: "/"
+  directories:
+  - "/src/HuggingfaceTokenizer/Rest"
   schedule:
     interval: "daily"
+  groups:
+    docker:
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: pip
-  directory: "/src/HuggingfaceTokenizer/BenchPython"
+  directories:
+  - "/src/HuggingfaceTokenizer/BenchPython"
+  - "/src/HuggingfaceTokenizer/Rest"
   schedule:
     interval: weekly
+  groups:
+    python:
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
+- package-ecosystem: cargo
+  directories:
+  - "/src/HuggingfaceTokenizer/BenchRust"
+  - "/src/HuggingfaceTokenizer/RustLib"
+  schedule:
+    interval: weekly
+  groups:
+    rust:
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch


### PR DESCRIPTION
Dependabot currently opens one PR per dependency, which is why there are a dozen individual bump PRs sitting open.

## Changes

- **Grouping**: every ecosystem gets a group matching `*` with `update-types: [minor, patch]`, so all non-breaking bumps of an ecosystem land in a single PR. Major bumps are deliberately left out of the groups and keep getting their own PR, so breaking updates can still be reviewed and merged one at a time.
- **cargo**: newly declared for `/src/HuggingfaceTokenizer/BenchRust` and `/src/HuggingfaceTokenizer/RustLib`. Dependabot was already opening PRs for these (#132, #137) even though the config never mentioned cargo; declaring them explicitly is what makes the grouping apply.
- **pip**: `/src/HuggingfaceTokenizer/Rest` added alongside `BenchPython` (same reason — #131, #140 exist but were unconfigured). Both directories share one `python` group.
- **docker**: pointed at `/src/HuggingfaceTokenizer/Rest`, the directory that actually holds a `Dockerfile`. The updater was configured for `/`, where there is none, so it had nothing to do.

Schedules are unchanged (daily for nuget/github-actions/docker, weekly for pip/cargo).

## Notes

The existing open Dependabot PRs are not superseded automatically — Dependabot rebuilds them into grouped PRs on its next run after this merges. I'm commenting `·@·d·ependabot r·ebase` on the open ones so they refresh against current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdzNFR5yk3GiFKFerN65ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdzNFR5yk3GiFKFerN65ay)_