### PR TITLE
Review cuts for the Python binding prototype: trim the ABI, fix empty parallel batch

### DIFF
--- a/src/FastBertTokenizer.Native/NativeExports.cs
+++ b/src/FastBertTokenizer.Native/NativeExports.cs
@@ -39,13 +39,7 @@ internal static unsafe class NativeExports
     private static long _nextHandle;
 
     [ThreadStatic]
-    private static string? _lastError;
-
-    [ThreadStatic]
-    private static string? _lastErrorMaterialized;
-
-    [ThreadStatic]
-    private static nint _lastErrorUtf8;
+    private static byte[]? _lastError;
 
     /// <summary>Create a new tokenizer instance. Returns an opaque handle, or 0 on failure.</summary>
     [UnmanagedCallersOnly(EntryPoint = "fbt_create", CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -74,7 +68,7 @@ internal static unsafe class NativeExports
     {
         if (handle != 0 && !Instances.TryRemove(handle, out _))
         {
-            _lastError = "handle does not refer to a live tokenizer instance.";
+            SetLastError("handle does not refer to a live tokenizer instance.");
         }
     }
 
@@ -94,7 +88,7 @@ internal static unsafe class NativeExports
 
             if (json is null || jsonByteLen < 0)
             {
-                _lastError = "json must not be null and jsonByteLen must be >= 0.";
+                SetLastError("json must not be null and jsonByteLen must be >= 0.");
                 return ErrInvalidArgument;
             }
 
@@ -125,7 +119,7 @@ internal static unsafe class NativeExports
 
             if (vocab is null || vocabByteLen < 0)
             {
-                _lastError = "vocab must not be null and vocabByteLen must be >= 0.";
+                SetLastError("vocab must not be null and vocabByteLen must be >= 0.");
                 return ErrInvalidArgument;
             }
 
@@ -144,8 +138,8 @@ internal static unsafe class NativeExports
     /// <summary>
     /// Encode a batch of UTF-8 texts. Writes <c>count * max_tokens</c> int64 values to
     /// <paramref name="inputIds"/> and <paramref name="attentionMask"/> (row-major, one padded row
-    /// per input). <paramref name="tokenTypeIds"/> may be null; if given it is zero-filled.
-    /// <paramref name="parallel"/> != 0 tokenizes on the .NET thread pool (recommended for large batches).
+    /// per input). <paramref name="parallel"/> != 0 tokenizes on the .NET thread pool
+    /// (recommended for large batches).
     /// </summary>
     [UnmanagedCallersOnly(EntryPoint = "fbt_encode_batch", CallConvs = new[] { typeof(CallConvCdecl) })]
     public static int EncodeBatch(
@@ -156,7 +150,6 @@ internal static unsafe class NativeExports
         int maxTokens,
         long* inputIds,
         long* attentionMask,
-        long* tokenTypeIds,
         int parallel)
     {
         try
@@ -169,14 +162,14 @@ internal static unsafe class NativeExports
             if (texts is null || textByteLens is null || inputIds is null || attentionMask is null
                 || count < 0 || maxTokens <= 0)
             {
-                _lastError = "texts, textByteLens, inputIds and attentionMask must not be null; count must be >= 0 and maxTokens > 0.";
+                SetLastError("texts, textByteLens, inputIds and attentionMask must not be null; count must be >= 0 and maxTokens > 0.");
                 return ErrInvalidArgument;
             }
 
             long totalLen = (long)count * maxTokens;
             if (totalLen > int.MaxValue)
             {
-                _lastError = $"count * maxTokens must be <= {int.MaxValue} per call; split the batch.";
+                SetLastError($"count * maxTokens must be <= {int.MaxValue} per call; split the batch.");
                 return ErrInvalidArgument;
             }
 
@@ -184,12 +177,17 @@ internal static unsafe class NativeExports
             {
                 if (textByteLens[i] < 0 || (texts[i] is null && textByteLens[i] > 0))
                 {
-                    _lastError = $"texts[{i}] is null with a positive length or textByteLens[{i}] is negative.";
+                    SetLastError($"texts[{i}] is null with a positive length or textByteLens[{i}] is negative.");
                     return ErrInvalidArgument;
                 }
             }
 
-            var inputs = MaterializeStrings(texts, textByteLens, count, parallel != 0);
+            var inputs = new string[count];
+            for (var i = 0; i < count; i++)
+            {
+                // A null pointer with length 0 is a valid empty input, but GetString(null, 0) throws.
+                inputs[i] = textByteLens[i] == 0 ? string.Empty : Encoding.UTF8.GetString(texts[i], textByteLens[i]);
+            }
 
             if (parallel != 0)
             {
@@ -210,49 +208,7 @@ internal static unsafe class NativeExports
                 }
             }
 
-            if (tokenTypeIds is not null)
-            {
-                new Span<long>(tokenTypeIds, (int)totalLen).Clear();
-            }
-
             return Ok;
-        }
-        catch (Exception ex)
-        {
-            SetLastError(ex);
-            return ErrException;
-        }
-    }
-
-    /// <summary>
-    /// Encode a single UTF-8 text. Writes up to <paramref name="maxTokens"/> int64 values to
-    /// <paramref name="inputIds"/> and <paramref name="attentionMask"/> (padded to <paramref name="maxTokens"/>).
-    /// Returns the number of non-padding tokens produced, or a negative error code.
-    /// </summary>
-    [UnmanagedCallersOnly(EntryPoint = "fbt_encode", CallConvs = new[] { typeof(CallConvCdecl) })]
-    public static int EncodeSingle(nint handle, byte* text, int textByteLen, int maxTokens, long* inputIds, long* attentionMask)
-    {
-        try
-        {
-            if (Resolve(handle) is not { } tok)
-            {
-                return ErrInvalidHandle;
-            }
-
-            if (text is null || inputIds is null || attentionMask is null || textByteLen < 0 || maxTokens <= 0)
-            {
-                _lastError = "text, inputIds and attentionMask must not be null; textByteLen must be >= 0 and maxTokens > 0.";
-                return ErrInvalidArgument;
-            }
-
-            var input = Encoding.UTF8.GetString(text, textByteLen);
-            var maskSpan = new Span<long>(attentionMask, maxTokens);
-            tok.Encode(input, new Span<long>(inputIds, maxTokens), maskSpan, padTo: maxTokens);
-
-            // With padTo set, Encode returns the padded length; the documented return value is
-            // the non-padding count, which the attention mask (1s followed by 0s) tells us.
-            var nonPadded = maskSpan.IndexOf(0L);
-            return nonPadded < 0 ? maxTokens : nonPadded;
         }
         catch (Exception ex)
         {
@@ -280,7 +236,7 @@ internal static unsafe class NativeExports
 
             if (tokenIds is null || count < 0 || outRequiredByteLen is null || outByteLen < 0)
             {
-                _lastError = "tokenIds and outRequiredByteLen must not be null; count and outByteLen must be >= 0.";
+                SetLastError("tokenIds and outRequiredByteLen must not be null; count and outByteLen must be >= 0.");
                 return ErrInvalidArgument;
             }
 
@@ -307,47 +263,18 @@ internal static unsafe class NativeExports
     /// or 0 if none occurred. The pointer stays valid until the next failing call on the same thread.
     /// </summary>
     [UnmanagedCallersOnly(EntryPoint = "fbt_last_error", CallConvs = new[] { typeof(CallConvCdecl) })]
-    public static nint LastError()
+    public static nint LastError() => _lastError is { } e ? Marshal.UnsafeAddrOfPinnedArrayElement(e, 0) : 0;
+
+    private static void SetLastError(Exception ex) => SetLastError(ex.ToString());
+
+    private static void SetLastError(string message)
     {
-        try
-        {
-            var msg = _lastError;
-            if (msg is null)
-            {
-                return 0;
-            }
-
-            // Repeated queries must return the same buffer while no new failure occurred - the
-            // documented lifetime is "valid until the next failing call on this thread". Only
-            // re-encode (and free the previous buffer) once the message actually changed.
-            if (_lastErrorUtf8 != 0 && ReferenceEquals(_lastErrorMaterialized, msg))
-            {
-                return _lastErrorUtf8;
-            }
-
-            if (_lastErrorUtf8 != 0)
-            {
-                NativeMemory.Free((void*)_lastErrorUtf8);
-                _lastErrorUtf8 = 0;
-            }
-
-            var bytes = Encoding.UTF8.GetBytes(msg);
-            var buf = (byte*)NativeMemory.Alloc((nuint)bytes.Length + 1);
-            bytes.CopyTo(new Span<byte>(buf, bytes.Length));
-            buf[bytes.Length] = 0;
-            _lastErrorUtf8 = (nint)buf;
-            _lastErrorMaterialized = msg;
-            return _lastErrorUtf8;
-        }
-        catch (Exception)
-        {
-            // Even allocation failure must not escape an [UnmanagedCallersOnly] export;
-            // "no message available" is the only safe answer here.
-            return 0;
-        }
+        // The buffer lives on the pinned object heap, so the returned pointer stays valid for as
+        // long as the thread-static references it - i.e. exactly the documented lifetime.
+        var buf = GC.AllocateUninitializedArray<byte>(Encoding.UTF8.GetByteCount(message) + 1, pinned: true);
+        buf[Encoding.UTF8.GetBytes(message, buf)] = 0;
+        _lastError = buf;
     }
-
-    private static void SetLastError(Exception ex) => _lastError = ex.ToString();
 
     private static BertTokenizer? Resolve(nint handle)
     {
@@ -356,41 +283,10 @@ internal static unsafe class NativeExports
             return tok;
         }
 
-        _lastError = handle == 0
+        SetLastError(handle == 0
             ? "handle must not be 0."
-            : "handle does not refer to a live tokenizer instance.";
+            : "handle does not refer to a live tokenizer instance.");
         return null;
-    }
-
-    private static string[] MaterializeStrings(byte** texts, int* textByteLens, int count, bool parallel)
-    {
-        var result = new string[count];
-
-        // Converting UTF-8 to .NET strings is a real share of small-batch runtime, so parallelize
-        // it alongside parallel tokenization. Pointers can't be captured by lambdas; smuggle them
-        // through nints.
-        if (parallel && count >= 256)
-        {
-            var textsAddr = (nint)texts;
-            var lensAddr = (nint)textByteLens;
-            Parallel.For(0, count, i =>
-            {
-                var t = ((byte**)textsAddr)[i];
-                var l = ((int*)lensAddr)[i];
-                result[i] = l == 0 || t is null ? string.Empty : Encoding.UTF8.GetString(t, l);
-            });
-        }
-        else
-        {
-            for (var i = 0; i < count; i++)
-            {
-                var t = texts[i];
-                var l = textByteLens[i];
-                result[i] = l == 0 || t is null ? string.Empty : Encoding.UTF8.GetString(t, l);
-            }
-        }
-
-        return result;
     }
 
     /// <summary>Exposes caller-owned native memory as <see cref="Memory{T}"/> without copying.</summary>

--- a/src/FastBertTokenizer.Tests/ParallelEncodeExceptions.cs
+++ b/src/FastBertTokenizer.Tests/ParallelEncodeExceptions.cs
@@ -38,4 +38,14 @@ public class ParallelEncodeExceptions
         var act = () => uut.Encode(inputs, iids, attm, 1);
         act.ShouldThrow<Exception>();
     }
+
+    [Fact]
+    public async Task EncodingEmptyBatchIsANoOp()
+    {
+        var uut = new BertTokenizer();
+        await uut.LoadTokenizerJsonAsync("data/bert-base-uncased/tokenizer.json");
+
+        Should.NotThrow(() => uut.Encode(Array.Empty<string>(), Array.Empty<long>(), Array.Empty<long>(), 128));
+        Should.NotThrow(() => uut.Encode(Array.Empty<string>(), Array.Empty<long>(), Array.Empty<long>(), Array.Empty<long>(), 128));
+    }
 }

--- a/src/FastBertTokenizer/BertTokenizer.Parallel.cs
+++ b/src/FastBertTokenizer/BertTokenizer.Parallel.cs
@@ -63,6 +63,11 @@ public partial class BertTokenizer
             throw new ArgumentException($"{nameof(inputIds)} and {nameof(attentionMask)} must have {resultLen} elements, but had {inputIds.Length} and {attentionMask.Length}.");
         }
 
+        if (inputs.Length == 0)
+        {
+            return;
+        }
+
         Tuple<int, int>[] ranges;
         if (_rangeCache is { } rc && rc.Count == inputs.Length)
         {

--- a/src/PythonBinding/README.md
+++ b/src/PythonBinding/README.md
@@ -43,18 +43,23 @@ Result: 3 of 15,000 documents (0.02 %) differ — the same known corpus-level di
 [`bench.py`](bench.py) mirrors the methodology of
 [`../HuggingfaceTokenizer/BenchPython/bench.py`](../HuggingfaceTokenizer/BenchPython/bench.py)
 (same corpus, same vocabulary, truncation at 512 tokens, pyperf). Measured in a 4-vCPU
-Linux x64 container (`pyperf --fast`, so treat as indicative rather than rigorous):
+Linux x64 container with tokie 0.1.4 and tokenizers 0.23.2. FastBertTokenizer and tokie rows
+use pyperf's default settings (mean ± std dev over 20 processes), the Hugging Face rows
+`pyperf --fast`. The container is shared and noisy, so treat the numbers as indicative:
 
 | Called from Python                  | Single-text loop | Batch (parallel) |
 |-------------------------------------|-----------------:|-----------------:|
-| **FastBertTokenizer (this binding)**|       **542 ms** |       **211 ms** |
-| tokie (Rust)                        |          1.11 s  |           830 ms |
-| Hugging Face tokenizers (Rust)      |          11.0 s  |           3.01 s |
+| **FastBertTokenizer (this binding)**|  **757 ± 42 ms** |  **296 ± 43 ms** |
+| tokie (Rust)                        |      723 ± 24 ms |      220 ± 13 ms |
+| Hugging Face tokenizers (Rust)      |          13.7 s  |           3.42 s |
 
-FastBertTokenizer's batch call additionally ran at 531 ms with `parallel=False`. At ~3.66 M
-tokens for the corpus, 211 ms is ≈17 M tokens/s from Python — including the Python → native
+FastBertTokenizer's batch call additionally ran at 617 ms with `parallel=False`. At ~3.66 M
+tokens for the corpus, 296 ms is ≈12 M tokens/s from Python — including the Python → native
 UTF-8 marshalling and numpy allocation, i.e. the interop cost does not eat the library's
-advantage.
+advantage over Hugging Face `tokenizers`. tokie is on par: note that tokie 0.1.0 (released
+2026-07-23) made its batch path roughly 3–4× faster than the 0.0.10 that
+[`../HuggingfaceTokenizer/BenchPython/requirements.txt`](../HuggingfaceTokenizer/BenchPython/requirements.txt)
+pins; against 0.0.10, this binding's batch call was ~4× faster than tokie's in the same setup.
 
 ## What a real release would still need
 

--- a/src/PythonBinding/README.md
+++ b/src/PythonBinding/README.md
@@ -30,7 +30,7 @@ tokenization uses all cores via the .NET thread pool.
 
 [`smoke.py`](smoke.py) exercises the C ABI contract itself: handle lifecycle (including
 stale/garbage/double-destroyed handles), error codes and last-error semantics, encode
-return values, per-item argument validation and the decode size-query protocol.
+outputs, per-item argument validation and the decode size-query protocol.
 
 [`verify.py`](verify.py) checks id-level parity against Hugging Face `tokenizers` on the
 benchmark corpus (15,000 simple english wikipedia articles), analogous to

--- a/src/PythonBinding/fastberttokenizer/__init__.py
+++ b/src/PythonBinding/fastberttokenizer/__init__.py
@@ -35,20 +35,13 @@ class NativeError(RuntimeError):
     """An error reported by the FastBertTokenizer native library."""
 
 
-def _validate_max_tokens(max_tokens: int) -> None:
-    if max_tokens <= 0:
-        raise ValueError("max_tokens must be > 0.")
-    if max_tokens > 2**31 - 1:
-        raise ValueError(f"max_tokens must be <= {2**31 - 1}.")
-
-
-def _default_lib_names() -> list[str]:
+def _lib_name() -> str:
     system = platform.system()
     if system == "Windows":
-        return ["FastBertTokenizer.Native.dll"]
+        return "FastBertTokenizer.Native.dll"
     if system == "Darwin":
-        return ["FastBertTokenizer.Native.dylib"]
-    return ["FastBertTokenizer.Native.so"]
+        return "FastBertTokenizer.Native.dylib"
+    return "FastBertTokenizer.Native.so"
 
 
 def _default_rid() -> str:
@@ -66,22 +59,16 @@ def _find_library() -> str:
             return override
         raise FileNotFoundError(f"FBT_NATIVE_LIB points to {override!r}, which does not exist.")
 
-    names = _default_lib_names()
-    pkg_dir = pathlib.Path(__file__).resolve().parent
-    # In a built wheel the native lib would ship inside the package; during repo-local
-    # development we fall back to the dotnet publish output.
-    repo_root = pkg_dir.parents[2]
-    publish_dir = (
-        repo_root / "bin" / "FastBertTokenizer.Native" / "Release" / "net10.0" / _default_rid() / "publish"
+    repo_root = pathlib.Path(__file__).resolve().parents[3]
+    candidate = (
+        repo_root / "bin" / "FastBertTokenizer.Native" / "Release" / "net10.0" / _default_rid()
+        / "publish" / _lib_name()
     )
-    candidates = [pkg_dir / n for n in names] + [publish_dir / n for n in names]
-    for candidate in candidates:
-        if candidate.is_file():
-            return str(candidate)
+    if candidate.is_file():
+        return str(candidate)
     raise FileNotFoundError(
-        "FastBertTokenizer native library not found. Looked for "
-        + ", ".join(str(c) for c in candidates)
-        + ". Build it with: dotnet publish src/FastBertTokenizer.Native -c Release -r "
+        f"FastBertTokenizer native library not found. Looked for {candidate}."
+        " Build it with: dotnet publish src/FastBertTokenizer.Native -c Release -r "
         + _default_rid()
     )
 
@@ -108,17 +95,7 @@ def _load(lib_path: str | None) -> ctypes.CDLL:
         ctypes.c_int32,                     # max_tokens
         ctypes.POINTER(ctypes.c_int64),     # input_ids out
         ctypes.POINTER(ctypes.c_int64),     # attention_mask out
-        ctypes.POINTER(ctypes.c_int64),     # token_type_ids out (nullable)
         ctypes.c_int32,                     # parallel
-    ]
-    lib.fbt_encode.restype = ctypes.c_int32
-    lib.fbt_encode.argtypes = [
-        ctypes.c_void_p,
-        ctypes.c_char_p,
-        ctypes.c_int32,
-        ctypes.c_int32,
-        ctypes.POINTER(ctypes.c_int64),
-        ctypes.POINTER(ctypes.c_int64),
     ]
     lib.fbt_decode.restype = ctypes.c_int32
     lib.fbt_decode.argtypes = [
@@ -178,7 +155,8 @@ class BertTokenizer:
         padded per row. The arrays can be fed directly to e.g. onnxruntime or torch.
         """
         count = len(texts)
-        _validate_max_tokens(max_tokens)
+        if max_tokens <= 0:
+            raise ValueError("max_tokens must be > 0.")
         # The native side rejects batches larger than this anyway; failing here avoids
         # allocating the (potentially huge) output arrays first.
         if count * max_tokens > 2**31 - 1:
@@ -187,12 +165,8 @@ class BertTokenizer:
             )
 
         encoded = [t.encode("utf-8") for t in texts]
-        if encoded and max(map(len, encoded)) > 2**31 - 1:
-            raise ValueError("a single text must not exceed 2 GiB of UTF-8 bytes.")
-
         input_ids = np.empty((count, max_tokens), dtype=np.int64)
         attention_mask = np.empty((count, max_tokens), dtype=np.int64)
-        token_type_ids = np.empty((count, max_tokens), dtype=np.int64) if return_token_type_ids else None
         text_array = (ctypes.c_char_p * count)(*encoded)
         len_array = (ctypes.c_int32 * count)(*(len(b) for b in encoded))
 
@@ -205,35 +179,18 @@ class BertTokenizer:
             max_tokens,
             input_ids.ctypes.data_as(int64_ptr),
             attention_mask.ctypes.data_as(int64_ptr),
-            token_type_ids.ctypes.data_as(int64_ptr) if token_type_ids is not None else None,
             1 if parallel else 0,
         )
         if rc != 0:
             self._raise("fbt_encode_batch", rc)
-        if token_type_ids is not None:
-            return input_ids, attention_mask, token_type_ids
+        if return_token_type_ids:
+            return input_ids, attention_mask, np.zeros((count, max_tokens), dtype=np.int64)
         return input_ids, attention_mask
 
     def encode(self, text: str, max_tokens: int = 512):
         """Encode a single text. Returns (input_ids, attention_mask) as 1-D numpy int64 arrays."""
-        _validate_max_tokens(max_tokens)
-        data = text.encode("utf-8")
-        if len(data) > 2**31 - 1:
-            raise ValueError("a single text must not exceed 2 GiB of UTF-8 bytes.")
-        input_ids = np.empty(max_tokens, dtype=np.int64)
-        attention_mask = np.empty(max_tokens, dtype=np.int64)
-        int64_ptr = ctypes.POINTER(ctypes.c_int64)
-        rc = self._lib.fbt_encode(
-            self._handle,
-            data,
-            len(data),
-            max_tokens,
-            input_ids.ctypes.data_as(int64_ptr),
-            attention_mask.ctypes.data_as(int64_ptr),
-        )
-        if rc < 0:
-            self._raise("fbt_encode", rc)
-        return input_ids, attention_mask
+        input_ids, attention_mask = self.encode_batch([text], max_tokens, parallel=False)
+        return input_ids[0], attention_mask[0]
 
     def decode(self, token_ids) -> str:
         """Decode token ids (any int sequence or numpy array) back to text."""

--- a/src/PythonBinding/smoke.py
+++ b/src/PythonBinding/smoke.py
@@ -40,6 +40,13 @@ def int64_ptr(arr):
     return arr.ctypes.data_as(ctypes.POINTER(ctypes.c_int64))
 
 
+def encode1(handle, text, max_tokens, ids, mask):
+    """Encode a single text through the batch entry point (count = 1, sequential)."""
+    texts = (ctypes.c_char_p * 1)(text)
+    lens = (ctypes.c_int32 * 1)(len(text))
+    return lib.fbt_encode_batch(handle, texts, lens, 1, max_tokens, int64_ptr(ids), int64_ptr(mask), 0)
+
+
 tok = BertTokenizer.from_tokenizer_json(TOKENIZER_JSON)
 lib = tok._lib
 ids = np.empty(8, dtype=np.int64)
@@ -47,12 +54,12 @@ mask = np.empty(8, dtype=np.int64)
 
 print("handle lifecycle:")
 check("create returns non-zero handle", tok._handle != 0)
-check("zero handle -> invalid handle", lib.fbt_encode(0, b"x", 1, 8, int64_ptr(ids), int64_ptr(mask)) == ERR_INVALID_HANDLE)
-check("garbage handle -> invalid handle", lib.fbt_encode(987654321, b"x", 1, 8, int64_ptr(ids), int64_ptr(mask)) == ERR_INVALID_HANDLE)
+check("zero handle -> invalid handle", encode1(0, b"x", 8, ids, mask) == ERR_INVALID_HANDLE)
+check("garbage handle -> invalid handle", encode1(987654321, b"x", 8, ids, mask) == ERR_INVALID_HANDLE)
 stale = lib.fbt_create()
 lib.fbt_destroy(stale)
 lib.fbt_destroy(stale)  # double destroy must be survivable
-check("stale handle after destroy -> invalid handle", lib.fbt_encode(stale, b"x", 1, 8, int64_ptr(ids), int64_ptr(mask)) == ERR_INVALID_HANDLE)
+check("stale handle after destroy -> invalid handle", encode1(stale, b"x", 8, ids, mask) == ERR_INVALID_HANDLE)
 
 print("loading:")
 unloaded = lib.fbt_create()
@@ -63,31 +70,30 @@ big_ids = np.empty((4, 128), dtype=np.int64)
 big_mask = np.empty((4, 128), dtype=np.int64)
 texts = (ctypes.c_char_p * 4)(b"a", b"b", b"c", b"d")
 lens = (ctypes.c_int32 * 4)(1, 1, 1, 1)
-rc = lib.fbt_encode_batch(unloaded, texts, lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), None, 1)
+rc = lib.fbt_encode_batch(unloaded, texts, lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), 1)
 check("parallel encode without vocabulary -> error, process survives", rc == ERR_EXCEPTION)
 lib.fbt_destroy(unloaded)
 
 print("encode:")
-rc = lib.fbt_encode(tok._handle, b"hi", 2, 8, int64_ptr(ids), int64_ptr(mask))
-check("returns non-padding count", rc == 3, f"got {rc}")
+encode1(tok._handle, b"hi", 8, ids, mask)
 check("attention mask matches count", int(mask.sum()) == 3)
-long_text = ("lorem ipsum dolor " * 20).encode()
-rc = lib.fbt_encode(tok._handle, long_text, len(long_text), 8, int64_ptr(ids), int64_ptr(mask))
-check("truncated input returns max_tokens", rc == 8, f"got {rc}")
+check("wrapper mask sum", int(tok.encode("hi", max_tokens=8)[1].sum()) == 3)
+check("wrapper truncates to max_tokens", int(tok.encode("lorem ipsum dolor " * 20, max_tokens=8)[1].sum()) == 8)
+check("empty batch (parallel) -> empty arrays", tok.encode_batch([], max_tokens=8)[0].shape == (0, 8))
 
 print("encode_batch argument validation:")
 bad_lens = (ctypes.c_int32 * 4)(1, -1, 1, 1)
-rc = lib.fbt_encode_batch(tok._handle, texts, bad_lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), None, 0)
+rc = lib.fbt_encode_batch(tok._handle, texts, bad_lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), 0)
 check("negative per-item length -> invalid argument", rc == ERR_INVALID_ARGUMENT)
 null_texts = (ctypes.c_char_p * 1)(None)
 one_len = (ctypes.c_int32 * 1)(3)
-rc = lib.fbt_encode_batch(tok._handle, null_texts, one_len, 1, 128, int64_ptr(big_ids), int64_ptr(big_mask), None, 0)
+rc = lib.fbt_encode_batch(tok._handle, null_texts, one_len, 1, 128, int64_ptr(big_ids), int64_ptr(big_mask), 0)
 check("null text with positive length -> invalid argument", rc == ERR_INVALID_ARGUMENT)
-rc = lib.fbt_encode_batch(tok._handle, None, lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), None, 0)
+rc = lib.fbt_encode_batch(tok._handle, None, lens, 4, 128, int64_ptr(big_ids), int64_ptr(big_mask), 0)
 check("null texts array -> invalid argument", rc == ERR_INVALID_ARGUMENT)
 
 print("decode:")
-lib.fbt_encode(tok._handle, b"hi", 2, 8, int64_ptr(ids), int64_ptr(mask))
+encode1(tok._handle, b"hi", 8, ids, mask)
 required = ctypes.c_int64()
 rc = lib.fbt_decode(tok._handle, int64_ptr(ids), 3, None, 0, ctypes.byref(required))
 check("size query -> buffer too small + required size", rc == ERR_BUFFER_TOO_SMALL and required.value > 0)
@@ -99,7 +105,7 @@ check("negative outByteLen -> invalid argument", rc == ERR_INVALID_ARGUMENT)
 check("wrapper empty decode", tok.decode([]) == "")
 
 print("last_error semantics:")
-lib.fbt_encode(0, b"x", 1, 8, int64_ptr(ids), int64_ptr(mask))  # provoke a failure
+encode1(0, b"x", 8, ids, mask)  # provoke a failure
 lib.fbt_last_error.restype = ctypes.c_void_p  # compare pointers, not bytes
 p1, p2 = lib.fbt_last_error(), lib.fbt_last_error()
 lib.fbt_last_error.restype = ctypes.c_char_p


### PR DESCRIPTION
Review of #138 for overengineering and correctness, targeting its branch so the cuts land in that PR. Net effect on code: **81 insertions, 207 deletions**; behaviour visible to Python users is unchanged, `smoke.py` (now 21 checks) and `verify.py` (still 3 of 15,000 documents differ from HF) stay green, and the .NET tests pass.

## Correctness

* **Empty batch on the parallel path threw.** `BertTokenizer.Encode(ReadOnlyMemory<string>, …)` passes `inputs.Length` straight to `Partitioner.Create(0, 0)`, which throws `ArgumentOutOfRangeException`. From Python, `tok.encode_batch([], parallel=True)` raised a `NativeError` while `parallel=False` returned empty arrays. Fixed in the library with an early return (this is reachable for .NET callers too) plus a unit test, and covered by a new smoke check.

## Cuts (no code is the best code)

* **`fbt_encode` is gone.** A single text is `fbt_encode_batch` with `count = 1`, and the non-padding count it derived from the attention mask is the mask sum. Python's `encode()` is now a two-line wrapper over `encode_batch`.
* **`tokenTypeIds` is gone from the ABI.** The binding returns `np.zeros` when `return_token_type_ids` is set; no reason to cross the boundary for that.
* **The `Parallel.For` string materialization is gone** (pointers smuggled through `nint`s, threshold at 256 items). A plain loop replaces it. Measured here it was worth roughly 10 % on the parallel batch call (211 → ~230 ms best case), not the "real share" its comment claimed, and not worth the code in a prototype.
* **`fbt_last_error` is one line.** The three thread-statics, the `NativeMemory` alloc/free dance, the `ReferenceEquals` cache and the try/catch are replaced by a single thread-static `byte[]` on the pinned object heap, materialized when the error is set. Same documented lifetime ("valid until the next failing call on this thread"), nothing to free, and the export can no longer throw because it no longer allocates.
* **Python-side guards that duplicated native validation are gone:** the two "single text > 2 GiB" scans and the int32 upper bound on `max_tokens`. The native side already answers negative lengths and non-positive `maxTokens` with `ErrInvalidArgument` and a message. The `count * max_tokens` guard stays because it avoids allocating huge output arrays only to have the call rejected.
* **Library lookup** is env override, then the `dotnet publish` directory. The speculative "inside a wheel" candidate is gone.

## Kept on purpose

The handle table (garbage/stale handles must not crash the host), `PointerMemoryManager<T>` (needed for zero-copy `Memory<long>` over caller buffers), the explicit cdecl convention, the per-item argument validation and the decode size-query protocol.

## Numbers, and a finding about tokie

The README table is refreshed from a `bench.py` run in this 4-vCPU container (FastBertTokenizer and tokie rows with pyperf's default 20 processes, HF rows with `--fast`):

| Called from Python | Single-text loop | Batch (parallel) |
|---|---:|---:|
| FastBertTokenizer (this binding) | 757 ± 42 ms | 296 ± 43 ms |
| tokie 0.1.4 (Rust) | 723 ± 24 ms | 220 ± 13 ms |
| Hugging Face tokenizers 0.23.2 (Rust) | 13.7 s | 3.42 s |

**tokie is on par now, not 4× slower.** The original table was measured on 2026-07-22 against tokie 0.0.10 (the version `src/HuggingfaceTokenizer/BenchPython/requirements.txt` pins); tokie 0.1.0 was released on 2026-07-23 and made its batch path roughly 3–4× faster. Only a small part of the change in the fbt batch row is due to the cuts here (best case 211 → 228 ms); the rest is this container's noise (fbt's parallel batch has notably higher variance than tokie's, plausibly because the range cache makes the partitioning static so one descheduled worker stalls the whole batch). The README now states the tokie version and says "on par" rather than "fastest". This probably also affects the main README's market overview, which is out of scope here.

## Noticed but not changed

`dotnet publish src/FastBertTokenizer.Native -r linux-x64` rewrites `src/FastBertTokenizer/packages.lock.json` with empty `…/linux-x64` runtime sections. Harmless locally, but it would fail `RestoreLockedMode` in CI once the native project is added to the pipeline; worth keeping in mind for the "what a real release would still need" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHka8sxVR84ysrS4rki5Bx