### PR TITLE
Cap WordPiece candidate length at the longest vocabulary entry

### DIFF
--- a/src/FastBertTokenizer.Tests/CompareToHuggingfaceTokenizer.cs
+++ b/src/FastBertTokenizer.Tests/CompareToHuggingfaceTokenizer.cs
@@ -209,6 +209,14 @@ namespace FastBertTokenizer.Tests
         // CJK ideographs are single tokens, kana and hangul are not; unicode and ascii punctuation.
         [InlineData("中文abc,你好。日本語テキスト한국어")]
 
+        // Word pieces are matched starting at the length of the longest vocabulary entry. "telecommunications"
+        // is exactly that longest entry for bert-base-uncased, the other words are longer than it and thus
+        // have to be assembled from several pieces. Words of more than 100 chars are not covered here, see
+        // the max_input_chars_per_word divergence below.
+        [InlineData("telecommunications and pneumonoultramicroscopicsilicovolcanoconiosis, antidisestablishmentarianism deforestation")]
+        [InlineData("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")]
+        [InlineData("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij")]
+
         // Known divergences from Hugging Face. Kept as skipped rows so they are documented and can be enabled once fixed.
         [InlineData("a\u000Bb\u000Cc\u0085d", Skip = "Hugging Face removes vertical tab, form feed and next line (U+0085) as control chars and encodes 'abcd'; we split on them as whitespace.")]
         [InlineData("англия", Skip = "Hugging Face encodes this as one token with the issue-100 tokenizer; we match its normalized added token 'Англ' case-insensitively although that tokenizer is cased.")]

--- a/src/FastBertTokenizer.Tests/LongWords.cs
+++ b/src/FastBertTokenizer.Tests/LongWords.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Georg Jung. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Shouldly;
+
+namespace FastBertTokenizer.Tests;
+
+/// <summary>
+/// A word piece can never be longer than the longest entry of the vocabulary, so the greedy longest-prefix
+/// match starts there instead of at the full word. These tests pin down that this does not change what is
+/// emitted - especially for candidates that are exactly as long as the longest entry - and that the work
+/// spent on a single word stays bounded by its length.
+/// </summary>
+public class LongWords
+{
+    // Token ids are line numbers. The longest prefix is "abcd" (4 chars), the longest suffix "xyz" (3 chars).
+    private const string VocabTxt = "[UNK]\n[CLS]\n[SEP]\n[PAD]\na\nab\nabcd\n##x\n##xyz\n";
+
+    private const long Unk = 0;
+    private const long Cls = 1;
+    private const long Sep = 2;
+    private const long A = 4;
+    private const long Ab = 5;
+    private const long Abcd = 6;
+    private const long SuffixX = 7;
+    private const long SuffixXyz = 8;
+
+    [Theory]
+
+    // Candidates that are exactly as long as the longest prefix/suffix must still be looked up.
+    [InlineData("abcd", new[] { Cls, Abcd, Sep })]
+    [InlineData("axyz", new[] { Cls, A, SuffixXyz, Sep })]
+
+    // Words longer than the longest prefix are matched piece by piece, as before.
+    [InlineData("abcdx", new[] { Cls, Abcd, SuffixX, Sep })]
+    [InlineData("abcdxyz", new[] { Cls, Abcd, SuffixXyz, Sep })]
+    [InlineData("abcdxyzx", new[] { Cls, Abcd, SuffixXyz, SuffixX, Sep })]
+
+    // Shorter than the longest prefix, thus unaffected by the cap.
+    [InlineData("ab", new[] { Cls, Ab, Sep })]
+    [InlineData("abc", new[] { Cls, Unk, Sep })]
+
+    // A word the vocabulary can't represent is unknown as a whole, no matter where the matching fails.
+    [InlineData("zzzz", new[] { Cls, Unk, Sep })]
+    [InlineData("abzz", new[] { Cls, Unk, Sep })]
+    [InlineData("abcdxyzzz", new[] { Cls, Unk, Sep })]
+    public void MatchesAtTheLengthOfTheLongestVocabularyEntry(string input, long[] expected)
+    {
+        var tokenizer = CreateTokenizer(VocabTxt);
+        tokenizer.Encode(input, 512).InputIds.ToArray().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void VocabularyWithoutSuffixesYieldsUnknownForMultiPieceWords()
+    {
+        // The longest suffix is 0 chars long here. Starting at that length needs to behave just like
+        // shrinking a candidate that never matches: the word as a whole is unknown.
+        var tokenizer = CreateTokenizer("[UNK]\n[CLS]\n[SEP]\n[PAD]\na\nab\n");
+        tokenizer.Encode("ab", 512).InputIds.ToArray().ShouldBe(new[] { Cls, Ab, Sep });
+        tokenizer.Encode("aab", 512).InputIds.ToArray().ShouldBe(new[] { Cls, Unk, Sep });
+    }
+
+    [Fact]
+    public void PathologicallyLongWordIsTokenizedInBoundedTime()
+    {
+        // A real vocabulary on purpose: what a failed lookup costs depends on the dictionary
+        // implementation, and for just a handful of entries some of them compare candidates by
+        // length instead of hashing them.
+        var tokenizer = new BertTokenizer();
+        using var vocabTxt = File.OpenText("data/bert-base-uncased/vocab.txt");
+        tokenizer.LoadVocabulary(vocabTxt, convertInputToLowercase: true);
+        var clsSep = tokenizer.Encode(string.Empty, 512).InputIds.ToArray();
+
+        // Every failed lookup hashes the whole candidate, so without starting at the length of the
+        // longest vocabulary entry this single word takes hours on net8.0/netstandard2.0 and ~160 ms
+        // on net9.0+ (where FrozenDictionary rejects overlong keys by length before hashing). Starting
+        // at the cap it is well below a millisecond. The timeout is generous on purpose - it is not a
+        // measurement, it just turns a regression into a failing test instead of a hanging test run.
+        var word = new string('a', 100_000);
+        var inputIds = Should.CompleteIn(() => tokenizer.Encode(word, 512).InputIds.ToArray(), TimeSpan.FromSeconds(30));
+
+        // The word is cut off at maximumTokens; only [CLS] and [SEP] are known here without hardcoding ids.
+        inputIds.Length.ShouldBe(512);
+        inputIds[0].ShouldBe(clsSep[0]);
+        inputIds[511].ShouldBe(clsSep[1]);
+    }
+
+    private static BertTokenizer CreateTokenizer(string vocabTxt)
+    {
+        var tokenizer = new BertTokenizer();
+        tokenizer.LoadVocabulary(new StringReader(vocabTxt), convertInputToLowercase: true);
+        return tokenizer;
+    }
+}

--- a/src/FastBertTokenizer/BertTokenizer.LoadTokenizerJson.cs
+++ b/src/FastBertTokenizer/BertTokenizer.LoadTokenizerJson.cs
@@ -166,6 +166,8 @@ public partial class BertTokenizer
         }
 
         _preTokenizer = new(tok.AddedTokens.Select(x => (x.Content, x.Normalized)).OrderByDescending(x => x.Content.Length));
+        _maxPrefixLength = MaxKeyLength(prefixes);
+        _maxSuffixLength = MaxKeyLength(suffixes);
 
 #if NET8_0_OR_GREATER
         _prefixes = prefixes.ToFrozenDictionary();

--- a/src/FastBertTokenizer/BertTokenizer.LoadVocab.cs
+++ b/src/FastBertTokenizer/BertTokenizer.LoadVocab.cs
@@ -147,6 +147,8 @@ public partial class BertTokenizer
             _cls = (clsId ?? throw new InvalidOperationException($"Vocabulary does not contain cls token {clsToken}."), clsToken);
             _sep = (sepId ?? throw new InvalidOperationException($"Vocabulary does not contain sep token {sepToken}."), sepToken);
             _pad = (padId ?? throw new InvalidOperationException($"Vocabulary does not contain pad token {padToken}."), padToken);
+            _maxPrefixLength = MaxKeyLength(prefixes);
+            _maxSuffixLength = MaxKeyLength(suffixes);
 
 #if NET8_0_OR_GREATER
             _prefixes = prefixes.ToFrozenDictionary();

--- a/src/FastBertTokenizer/BertTokenizer.cs
+++ b/src/FastBertTokenizer/BertTokenizer.cs
@@ -33,6 +33,8 @@ public partial class BertTokenizer
     private Dictionary<StringSpanOrdinalKey, long>? _prefixes;
     private Dictionary<StringSpanOrdinalKey, long>? _suffixes;
 #endif
+    private int _maxPrefixLength;
+    private int _maxSuffixLength;
     private (int Id, string Token) _unk = default!;
     private (int Id, string Token) _cls = default!;
     private (int Id, string Token) _sep = default!;
@@ -550,7 +552,11 @@ public partial class BertTokenizer
         }
 
         // No null checks for _prefixes and _suffixes because this is a private method.
-        var prefix = word;
+
+        // Candidates longer than the longest entry in the vocabulary can never match, so start
+        // shrinking at that length. Every failed lookup hashes the whole candidate, thus without
+        // this cap a single word of length n costs O(n^2) char hashing before the first match.
+        var prefix = word.Slice(0, Math.Min(word.Length, _maxPrefixLength));
         var cnt = 0;
         long id = -1;
 
@@ -577,7 +583,7 @@ public partial class BertTokenizer
         offset += prefix.Length;
         while (remaining.Length > 0 && cnt < tokenIdSink.Length)
         {
-            var suffix = remaining;
+            var suffix = remaining.Slice(0, Math.Min(remaining.Length, _maxSuffixLength));
             id = -1;
 
             while (suffix.Length > 0)
@@ -604,6 +610,41 @@ public partial class BertTokenizer
 
         return cnt;
     }
+
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Determines the length of the longest key of the given vocabulary dictionary.
+    /// </summary>
+    /// <param name="dict">The dictionary to inspect.</param>
+    /// <returns>The length of the longest key, or 0 if the dictionary is empty.</returns>
+    private static int MaxKeyLength(Dictionary<string, long> dict)
+    {
+        var max = 0;
+        foreach (var key in dict.Keys)
+        {
+            max = Math.Max(max, key.Length);
+        }
+
+        return max;
+    }
+#else
+    /// <summary>
+    /// Determines the length of the longest key of the given vocabulary dictionary.
+    /// </summary>
+    /// <param name="dict">The dictionary to inspect.</param>
+    /// <returns>The length of the longest key, or 0 if the dictionary is empty.</returns>
+    private static int MaxKeyLength(Dictionary<StringSpanOrdinalKey, long> dict)
+    {
+        var max = 0;
+        foreach (var key in dict.Keys)
+        {
+            // Keys that are stored in the dictionary are always string-backed; only lookups use the span-backed form.
+            max = Math.Max(max, key.Data!.Length);
+        }
+
+        return max;
+    }
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryGetPrefixId(ReadOnlySpan<char> prefix, out long id)


### PR DESCRIPTION
This is validated change 2 of #136, rebuilt on top of current master (which already carries part 1 in its reworked form). #136 itself can be closed once this lands.

## The problem

`TokenizeSubword` matches greedily: it starts with the whole remaining word and shrinks the candidate by one char until the vocabulary contains it. Every failed lookup hashes the whole candidate, and the suffix loop restarts at the full remainder for *every* piece it emits, so the work for one word grows far faster than the number of tokens it produces:

| word | net8.0 | net10.0 |
|---|---|---|
| 1 000 chars | 75.8 ms | 3.7 ms |
| 10 000 chars | 20 643 ms | 17.4 ms |
| 100 000 chars | did not finish (extrapolates to hours) | 181 ms |

(single `Encode(word, 512)` of a word of `n` times `'a'`, `data/bert-base-uncased/tokenizer.json`, Release, min of 5 after warmup, x64 Linux cloud VM.)

net9.0+ is the mild case only because `FrozenDictionary<string, long>` rejects overlong keys by a length comparison before hashing them. On net8.0 the keys are `StringSpanOrdinalKey`, whose hash covers the whole span, and netstandard2.0 does the same with a plain `Dictionary`.

That is also the bound an adversarial input can push against for anything that tokenizes untrusted text. Hugging Face guards the same case with `max_input_chars_per_word = 100`; FastBertTokenizer had no equivalent limit.

## The change

Both loaders record the length of the longest prefix and of the longest suffix in the vocabulary, and `TokenizeSubword` starts shrinking there instead of at the full word:

```csharp
var prefix = word.Slice(0, Math.Min(word.Length, _maxPrefixLength));
```

After the change the same encodes take 0.36 ms / 0.35 ms / 0.47 ms on net8.0 and 0.36 ms / 0.37 ms / 0.50 ms on net10.0 — flat in the word length, because only the 512 emitted tokens and the pre-tokenizer's scan over the input remain.

**What is emitted cannot change**: the skipped candidates are longer than every entry in the vocabulary, so none of them could ever have been found. For `bert-base-uncased` the caps are 18 chars for prefixes and 10 for suffixes.

Interleaved A/B over the wiki-simple corpus (15 000 articles, 26.3 M chars, `Encode(article, 512)`, 3 rounds each, net10.0) shows no regression on normal text: base min 234.1 ms, with the cap min 234.5 ms — both fluctuate between 234 and 257 ms on this VM.

## Tests

`Add crafted long-word parity cases` comes first on purpose: those rows pass before *and* after the change, against the real Hugging Face tokenizer, for all three tokenizers of that theory.

- **Hugging Face parity** (`CompareToHuggingfaceTokenizer.cs`): a word that is exactly as long as the longest vocabulary entry (`telecommunications`), words that have to be assembled from several pieces, and a 100 char word — that is the longest word Hugging Face still tokenizes piece by piece before `max_input_chars_per_word` kicks in, so it is the longest one that can be compared at all. The already documented divergence above that limit stays skipped and untouched.
- **`LongWords.cs`** pins the boundaries down on a hand-written vocabulary whose longest prefix is 4 and longest suffix 3 chars, so the exact ids are readable from the test: candidates exactly at the cap still match, longer words are assembled piece by piece, and words the vocabulary cannot represent stay a single `[UNK]`. Reverting either cap to `- 1` fails 6 resp. 5 of these rows.
- A vocabulary without any `##` entries covers the `Math.Min(…, 0)` corner, where the cap has to behave like a candidate that never matches. `data/added-token-order.json` is such a vocabulary, so the parity rows above exercise it against Hugging Face too.
- `PathologicallyLongWordIsTokenizedInBoundedTime` encodes a 100 000 char word against the real `bert-base-uncased` vocabulary within a deliberately generous 30 s timeout. It is not a measurement — it turns a regression into a failing test instead of a test run that hangs for hours on net8.0 and net48.

Full suite green on net8.0 and net10.0 (110 passed, 12 skipped, the 12 being the pre-existing documented divergences). net48 was not run here — no Windows in this environment — but it shares the netstandard2.0 code path with net8.0 for everything this touches, and the library builds clean for all three TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJpdfPnbMeSVUBdFcnHerh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJpdfPnbMeSVUBdFcnHerh)_